### PR TITLE
add gemini local llm and local caches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,12 @@
+# API mode (default)
 MUAPI_API_KEY=your_muapi_key_here
+
+# Local mode (--mode local)
+LLM_PROVIDER=openai           # openai or gemini
+OPENAI_API_KEY=your_openai_key_here
+OPENAI_MODEL=gpt-4o-mini
+GEMINI_API_KEY=your_gemini_key_here
+GEMINI_MODEL=gemini-2.5-flash
+LOCAL_WHISPER_MODEL=base
+LOCAL_WHISPER_DEVICE=auto
+LOCAL_OUTPUT_DIR=output

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Built for creators, agencies, and developers who don't want to pay $20–$300/mo
 ## Features
 
 - **🎬 YouTube In, Vertical Out**: Hand it any YouTube URL — get back N viral-ready 9:16 mp4s
-- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, OpenAI, and `ffmpeg`/`opencv` — pick what fits
+- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, and `ffmpeg`/`opencv`, and lets you pick OpenAI or Gemini for highlight ranking
 - **🤖 Virality-Aware Highlight Selection**: Clips ranked on hooks, emotional peaks, opinion bombs, revelation moments, conflict, quotable lines, story peaks, and practical value — not just generic "interesting"
 - **📈 Score + Hook + Reason for Every Clip**: Each highlight comes with a viral score, an opening hook line, and a one-sentence explanation of why it works
 - **🎤 Whisper Transcription, Your Choice**: Cloud (`/openai-whisper` via MuAPI) or local (`faster-whisper`, CPU or CUDA) — same downstream output shape
@@ -50,7 +50,7 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
 
 - Python 3.10+
 - For **API mode (default)**: a MuAPI key — powers download, transcription, highlight ranking, and clipping in a single dependency
-- For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an `OPENAI_API_KEY` (only the LLM step is remote; everything else runs offline)
+- For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an LLM API key (`OPENAI_API_KEY` or `GEMINI_API_KEY`; only the LLM step is remote)
 
 ### Steps
 
@@ -80,9 +80,12 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
    # API mode (default)
    MUAPI_API_KEY=your_muapi_key_here
 
-   # Local mode (--mode local) — only the OPENAI key is required
+   # Local mode (--mode local)
+   LLM_PROVIDER=openai         # openai or gemini
    OPENAI_API_KEY=your_openai_key_here
    OPENAI_MODEL=gpt-4o-mini          # optional, default gpt-4o-mini
+   GEMINI_API_KEY=your_gemini_key_here
+   GEMINI_MODEL=gemini-2.5-flash      # optional, default gemini-2.5-flash
    LOCAL_WHISPER_MODEL=base          # tiny / base / small / medium / large-v3
    LOCAL_WHISPER_DEVICE=auto         # auto / cpu / cuda
    LOCAL_OUTPUT_DIR=output           # where local mp4s land
@@ -114,21 +117,37 @@ python main.py "https://www.youtube.com/watch?v=VIDEO_ID" \
     --output-json result.json
 ```
 
-### Local file
+### Local file or path
 
-Drop in a hosted mp4 URL directly via the Python API (the CLI is YouTube-first):
+In `--mode local`, you can pass a `file://` URL or a direct filesystem path and skip YouTube entirely:
+
+```bash
+python main.py "/Users/you/Videos/input.mp4" --mode local
+python main.py "file:///Users/you/Videos/input.mp4" --mode local
+```
+
+The Python API works the same way:
 
 ```python
 from shorts_generator import generate_shorts
 
 result = generate_shorts(
-    "https://www.youtube.com/watch?v=...",
+    "/Users/you/Videos/input.mp4",
     num_clips=5,
     aspect_ratio="9:16",
+    mode="local",
 )
 for short in result["shorts"]:
     print(short["score"], short["title"], short["clip_url"])
 ```
+
+Local transcription is cached as an `.srt` file in `LOCAL_OUTPUT_DIR` using the
+video's base name. If the cache already exists and is newer than the source
+file, the app reuses it instead of running Whisper again.
+
+Local downloads are also cached in `LOCAL_OUTPUT_DIR` as
+`source_<youtube_id>.mp4` when the input is a YouTube URL. If that file already
+exists, the app skips `yt-dlp` and reuses the cached video.
 
 ### Batch processing
 
@@ -142,7 +161,7 @@ xargs -a urls.txt -I{} python main.py "{}"
 
 | Flag | Default | Notes |
 |------|---------|-------|
-| `--mode` | `api` | `api` (MuAPI, fast, no setup) or `local` (yt-dlp + faster-whisper + OpenAI + ffmpeg) |
+| `--mode` | `api` | `api` (MuAPI, fast, no setup) or `local` (remote URL, `file://`, or local path + faster-whisper + LLM provider + ffmpeg) |
 | `--num-clips` | `3` | How many shorts to render |
 | `--aspect-ratio` | `9:16` | Any ratio; `9:16` for TikTok/Reels, `1:1` for square |
 | `--format` | `720` | Source download resolution: `360` / `480` / `720` / `1080` |
@@ -153,12 +172,12 @@ xargs -a urls.txt -I{} python main.py "{}"
 
 | Step | API mode (`--mode api`) | Local mode (`--mode local`) |
 |---|---|---|
-| Download | MuAPI `/youtube-download` | `yt-dlp` |
+| Download | MuAPI `/youtube-download` | `yt-dlp` for remote URLs, direct file path for local inputs |
 | Transcription | MuAPI `/openai-whisper` | `faster-whisper` (CPU or CUDA) |
-| Highlight LLM | MuAPI `gpt-5-mini` | OpenAI (`gpt-4o-mini` by default) |
+| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default) |
 | Vertical crop | MuAPI `/autocrop` | `ffmpeg` + OpenCV face tracking |
 | Output | hosted URLs | local mp4 paths |
-| Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY` (+ `ffmpeg` on PATH) |
+| Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY` or `GEMINI_API_KEY` (+ `ffmpeg` on PATH) |
 
 ## How It Works
 
@@ -238,7 +257,7 @@ AI-Youtube-Shorts-Generator/
 ├── requirements-local.txt        optional deps for --mode local
 ├── .env.example
 └── shorts_generator/
-    ├── config.py                 env / settings (MuAPI + OpenAI + Whisper)
+    ├── config.py                 env / settings (MuAPI + local LLM + Whisper)
     ├── muapi.py                  generic submit + poll wrapper
     ├── downloader.py             API mode: YouTube download via MuAPI
     ├── transcriber.py            API mode: MuAPI /openai-whisper client
@@ -248,7 +267,7 @@ AI-Youtube-Shorts-Generator/
     └── local/                    --mode local backends (offline)
         ├── downloader.py         yt-dlp download
         ├── transcriber.py        faster-whisper transcription
-        ├── llm.py                OpenAI chat-completions client
+        ├── llm.py                OpenAI or Gemini client selector
         └── clipper.py            ffmpeg cut + OpenCV vertical crop
 ```
 

--- a/main.py
+++ b/main.py
@@ -13,12 +13,12 @@ from shorts_generator import generate_shorts
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="AI YouTube Shorts Generator")
-    parser.add_argument("url", help="YouTube video URL")
+    parser.add_argument("url", help="YouTube URL, file:// URL, or local file path")
     parser.add_argument(
         "--mode",
         choices=["api", "local"],
         default="api",
-        help="api (default, MuAPI) or local (yt-dlp + faster-whisper + OpenAI + ffmpeg).",
+        help="api (default, MuAPI) or local (remote URL, file://, or local path + faster-whisper + LLM provider + ffmpeg).",
     )
     parser.add_argument("--num-clips", type=int, default=3, help="How many shorts to render (default: 3)")
     parser.add_argument("--aspect-ratio", default="9:16", help="Output aspect ratio (default: 9:16)")

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -1,8 +1,10 @@
+-r requirements.txt
+
 # Optional dependencies for --mode local.
-# Install on top of requirements.txt:  pip install -r requirements-local.txt
 yt-dlp>=2024.1.1
 faster-whisper>=1.0.0
 openai>=1.0.0
+google-genai>=1.0.0
 opencv-python>=4.8.0
 # torch is only needed if you want CUDA Whisper. CPU works without it.
 # torch>=2.0

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -13,6 +13,9 @@ POLL_TIMEOUT_SECONDS = float(os.getenv("MUAPI_POLL_TIMEOUT", "600"))
 # Local-mode (--mode local) settings — only consulted when running offline.
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "").strip()
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda
 LOCAL_OUTPUT_DIR = os.getenv("LOCAL_OUTPUT_DIR", "output")
@@ -33,3 +36,12 @@ def require_openai_key() -> str:
             "Add it to your .env or export it, or switch back to --mode api."
         )
     return OPENAI_API_KEY
+
+
+def require_gemini_key() -> str:
+    if not GEMINI_API_KEY:
+        raise RuntimeError(
+            "GEMINI_API_KEY is not set. Local mode needs a Gemini key when LLM_PROVIDER=gemini. "
+            "Add it to your .env or export it, or switch LLM_PROVIDER back to openai."
+        )
+    return GEMINI_API_KEY

--- a/shorts_generator/highlights.py
+++ b/shorts_generator/highlights.py
@@ -7,7 +7,7 @@ Logic ported from ViralVadoo's transcript_analysis/highlight_generator.py:
   - score-based dedupe with overlap suppression
 
 The LLM call is pluggable via the `llm_fn` argument so the same prompts can
-drive either MuAPI (default, --mode api) or a direct OpenAI client
+drive either MuAPI (default, --mode api) or a direct local LLM client
 (--mode local).
 """
 import json
@@ -199,7 +199,7 @@ def get_highlights(
     """Main entry point — returns {highlights: [...]} sorted by score.
 
     `llm_fn` swaps the underlying LLM. Defaults to MuAPI gpt-5-mini; local
-    mode passes in an OpenAI-backed callable.
+    mode passes in a local LLM-backed callable.
     """
     llm_fn = llm_fn or call_muapi_llm
     duration = transcript.get("duration", 0)

--- a/shorts_generator/local/__init__.py
+++ b/shorts_generator/local/__init__.py
@@ -1,6 +1,6 @@
 """Local-mode backends — no MuAPI calls, runs on your machine.
 
 Used when the pipeline is invoked with mode="local". Requires the optional
-deps in requirements-local.txt (yt-dlp, faster-whisper, openai, opencv,
-moviepy) plus an OPENAI_API_KEY for highlight ranking.
+deps in requirements-local.txt (yt-dlp, faster-whisper, openai, google-genai,
+opencv, moviepy) plus an LLM API key for highlight ranking.
 """

--- a/shorts_generator/local/downloader.py
+++ b/shorts_generator/local/downloader.py
@@ -4,6 +4,9 @@ Returns a local mp4 path so the rest of the local pipeline can read it
 directly off disk.
 """
 import os
+import re
+from pathlib import Path
+from urllib.parse import parse_qs, unquote, urlparse
 from typing import Optional
 
 from ..config import LOCAL_OUTPUT_DIR
@@ -32,11 +35,80 @@ def _format_for(fmt: str) -> str:
     )
 
 
+def _extract_youtube_video_id(source: str) -> Optional[str]:
+    """Best-effort extraction of a YouTube video id from a URL."""
+    parsed = urlparse(source)
+    host = (parsed.netloc or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+
+    if host in ("youtu.be", "www.youtu.be"):
+        video_id = parsed.path.lstrip("/").split("/", 1)[0]
+        return video_id or None
+
+    if "youtube.com" in host:
+        if parsed.path.startswith("/watch"):
+            qs = parse_qs(parsed.query)
+            video_id = qs.get("v", [""])[0]
+            return video_id or None
+        match = re.search(r"/(?:shorts|embed|live)/([^/?#&]+)", parsed.path)
+        if match:
+            return match.group(1)
+
+    return None
+
+
+def _resolve_local_path(source: str) -> Optional[str]:
+    """Return a local filesystem path if the input already points at one."""
+    parsed = urlparse(source)
+    if parsed.scheme == "file":
+        raw_path = unquote(parsed.path)
+        if parsed.netloc and parsed.netloc not in ("", "localhost"):
+            raw_path = f"//{parsed.netloc}{raw_path}"
+        candidate = Path(raw_path).expanduser()
+        if candidate.exists() and candidate.is_file():
+            return str(candidate.resolve())
+        raise RuntimeError(f"Local file URL does not exist: {source}")
+
+    if parsed.scheme in ("http", "https"):
+        return None
+
+    candidate = Path(source).expanduser()
+    if candidate.exists() and candidate.is_file():
+        return str(candidate.resolve())
+
+    if any(sep in source for sep in (os.sep, "/")) or source.startswith("~") or source.startswith("."):
+        raise RuntimeError(f"Local file path does not exist: {source}")
+
+    return None
+
+
+def _existing_download(out_dir: str, video_id: str) -> Optional[str]:
+    """Return a cached download path if we already have this YouTube id."""
+    for ext in (".mp4", ".mkv", ".webm"):
+        candidate = os.path.join(out_dir, f"source_{video_id}{ext}")
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
 def download_youtube_local(video_url: str, fmt: str = "720", out_dir: Optional[str] = None) -> str:
-    """Download to disk and return the local mp4 path."""
+    """Download a remote URL or return a local file path unchanged."""
+    local_path = _resolve_local_path(video_url)
+    if local_path:
+        print(f"[download/local] using local file: {local_path}", flush=True)
+        return local_path
+
     yt_dlp = _import_ytdlp()
     out_dir = out_dir or LOCAL_OUTPUT_DIR
     os.makedirs(out_dir, exist_ok=True)
+
+    video_id = _extract_youtube_video_id(video_url)
+    if video_id:
+        cached = _existing_download(out_dir, video_id)
+        if cached:
+            print(f"[download/local] reusing cached download: {cached}", flush=True)
+            return cached
 
     print(f"[download/local] {video_url} @ {fmt}p → {out_dir}/", flush=True)
     ydl_opts = {

--- a/shorts_generator/local/llm.py
+++ b/shorts_generator/local/llm.py
@@ -1,5 +1,11 @@
-"""Local LLM backend — calls OpenAI directly so no MuAPI account is needed."""
-from ..config import OPENAI_MODEL, require_openai_key
+"""Local LLM backend — OpenAI or Gemini, selected by LLM_PROVIDER."""
+from ..config import (
+    GEMINI_MODEL,
+    LLM_PROVIDER,
+    OPENAI_MODEL,
+    require_gemini_key,
+    require_openai_key,
+)
 
 
 def call_openai_llm(prompt: str) -> str:
@@ -19,3 +25,38 @@ def call_openai_llm(prompt: str) -> str:
         messages=[{"role": "user", "content": prompt}],
     )
     return response.choices[0].message.content or ""
+
+
+def call_gemini_llm(prompt: str) -> str:
+    """Gemini backend used by --mode local when LLM_PROVIDER=gemini."""
+    try:
+        from google import genai  # type: ignore
+    except ImportError as e:
+        raise RuntimeError(
+            "google-genai is required for LLM_PROVIDER=gemini. Install it with:\n"
+            "    pip install -r requirements-local.txt"
+        ) from e
+
+    client = genai.Client(api_key=require_gemini_key())
+    response = client.models.generate_content(
+        model=GEMINI_MODEL,
+        contents=prompt,
+        config={
+            "temperature": 0.2,
+            "response_mime_type": "application/json",
+            "max_output_tokens": 8192,
+        },
+    )
+    return response.text or ""
+
+
+def call_local_llm(prompt: str) -> str:
+    """Dispatch to the configured local LLM provider."""
+    provider = (LLM_PROVIDER or "openai").strip().lower()
+    if provider == "openai":
+        return call_openai_llm(prompt)
+    if provider == "gemini":
+        return call_gemini_llm(prompt)
+    raise RuntimeError(
+        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai' or 'gemini'."
+    )

--- a/shorts_generator/local/transcriber.py
+++ b/shorts_generator/local/transcriber.py
@@ -3,9 +3,82 @@
 Reads a local media file and returns the same shape the highlight generator
 expects: {duration, segments[start, end, text]}.
 """
+import os
+import re
+from pathlib import Path
 from typing import Dict, Optional
 
-from ..config import LOCAL_WHISPER_DEVICE, LOCAL_WHISPER_MODEL
+from ..config import LOCAL_OUTPUT_DIR, LOCAL_WHISPER_DEVICE, LOCAL_WHISPER_MODEL
+
+
+def _transcript_cache_path(media_path: str) -> Path:
+    """Return the .srt cache path for a media file."""
+    cache_dir = Path(LOCAL_OUTPUT_DIR)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / (Path(media_path).stem + ".srt")
+
+
+def _format_srt_timestamp(seconds: float) -> str:
+    total_ms = max(0, int(round(seconds * 1000)))
+    ms = total_ms % 1000
+    total_s = total_ms // 1000
+    s = total_s % 60
+    total_m = total_s // 60
+    m = total_m % 60
+    h = total_m // 60
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def _parse_srt_timestamp(value: str) -> float:
+    match = re.fullmatch(r"(\d{2}):(\d{2}):(\d{2}),(\d{3})", value.strip())
+    if not match:
+        raise ValueError(f"Invalid SRT timestamp: {value!r}")
+    hours, minutes, seconds, millis = map(int, match.groups())
+    return hours * 3600 + minutes * 60 + seconds + (millis / 1000.0)
+
+
+def _write_srt_cache(media_path: str, transcript: Dict) -> Path:
+    cache_path = _transcript_cache_path(media_path)
+    lines = []
+    for idx, segment in enumerate(transcript.get("segments", []), start=1):
+        start = _format_srt_timestamp(float(segment["start"]))
+        end = _format_srt_timestamp(float(segment["end"]))
+        text = str(segment.get("text", "")).strip().replace("\r", "").replace("\n", " ")
+        lines.append(str(idx))
+        lines.append(f"{start} --> {end}")
+        lines.append(text)
+        lines.append("")
+
+    cache_path.write_text("\n".join(lines), encoding="utf-8")
+    return cache_path
+
+
+def _load_srt_cache(cache_path: Path) -> Dict:
+    content = cache_path.read_text(encoding="utf-8-sig").strip()
+    if not content:
+        return {"duration": 0.0, "segments": []}
+
+    segments = []
+    for block in re.split(r"\n\s*\n", content):
+        lines = [line.strip("\ufeff") for line in block.splitlines() if line.strip()]
+        if not lines:
+            continue
+        if "-->" not in lines[0] and len(lines) > 1 and "-->" in lines[1]:
+            lines = lines[1:]
+        if not lines or "-->" not in lines[0]:
+            continue
+        start_raw, end_raw = [part.strip() for part in lines[0].split("-->", 1)]
+        text = "\n".join(lines[1:]).strip()
+        segments.append(
+            {
+                "start": _parse_srt_timestamp(start_raw),
+                "end": _parse_srt_timestamp(end_raw),
+                "text": text,
+            }
+        )
+
+    duration = segments[-1]["end"] if segments else 0.0
+    return {"duration": duration, "segments": segments}
 
 
 def _resolve_device() -> str:
@@ -19,7 +92,21 @@ def _resolve_device() -> str:
 
 
 def transcribe_local(media_path: str, language: Optional[str] = None) -> Dict:
-    """Run faster-whisper on a local file path."""
+    """Run faster-whisper on a local file path, caching the result as .srt."""
+    cache_path = _transcript_cache_path(media_path)
+    if cache_path.exists():
+        source_mtime = os.path.getmtime(media_path)
+        cache_mtime = cache_path.stat().st_mtime
+        if cache_mtime >= source_mtime:
+            print(f"[transcribe/local] reusing cached transcript: {cache_path}", flush=True)
+            cached = _load_srt_cache(cache_path)
+            print(
+                f"[transcribe/local] {len(cached['segments'])} cached segments, "
+                f"{cached['duration']:.0f}s of audio",
+                flush=True,
+            )
+            return cached
+
     try:
         from faster_whisper import WhisperModel  # type: ignore
     except ImportError as e:
@@ -51,4 +138,7 @@ def transcribe_local(media_path: str, language: Optional[str] = None) -> Dict:
 
     duration = float(getattr(info, "duration", 0.0)) or (segments[-1]["end"] if segments else 0.0)
     print(f"[transcribe/local] {len(segments)} segments, {duration:.0f}s of audio", flush=True)
-    return {"duration": duration, "segments": segments}
+    transcript = {"duration": duration, "segments": segments}
+    cache_path = _write_srt_cache(media_path, transcript)
+    print(f"[transcribe/local] wrote cache: {cache_path}", flush=True)
+    return transcript

--- a/shorts_generator/pipeline.py
+++ b/shorts_generator/pipeline.py
@@ -3,8 +3,8 @@
 Two modes:
   * mode="api"   (default) — MuAPI does download / transcribe / LLM / autocrop.
                               Fast, no local deps, pay-per-call.
-  * mode="local"            — yt-dlp + faster-whisper + OpenAI + ffmpeg/opencv.
-                              Self-hosted, OPENAI_API_KEY required for the LLM.
+  * mode="local"            — yt-dlp + faster-whisper + OpenAI or Gemini + ffmpeg/opencv.
+                              Self-hosted, LLM_PROVIDER selects OpenAI or Gemini.
 """
 from typing import Dict, List, Optional
 
@@ -23,7 +23,7 @@ def _run_local(
 ) -> Dict:
     from .local.clipper import crop_highlights_local
     from .local.downloader import download_youtube_local
-    from .local.llm import call_openai_llm
+    from .local.llm import call_local_llm
     from .local.transcriber import transcribe_local
 
     source_path = download_youtube_local(youtube_url, fmt=download_format)
@@ -34,7 +34,7 @@ def _run_local(
             "Whisper produced no segments. The video may have no detectable speech."
         )
 
-    highlights_result = get_highlights(transcript, num_clips=num_clips, llm_fn=call_openai_llm)
+    highlights_result = get_highlights(transcript, num_clips=num_clips, llm_fn=call_local_llm)
     all_highlights: List[Dict] = highlights_result.get("highlights", [])
     if not all_highlights:
         raise RuntimeError("Highlight generator returned zero clips.")
@@ -104,7 +104,7 @@ def generate_shorts(
         download_format: source resolution ("360" / "480" / "720" / "1080").
         language: ISO-639-1 to force Whisper language detection.
         mode: "api" (default, MuAPI) or "local" (yt-dlp + faster-whisper +
-            OpenAI + ffmpeg).
+            OpenAI or Gemini + ffmpeg).
 
     Returns:
         {


### PR DESCRIPTION
## Summary

This PR improves the local pipeline by making it more flexible, faster on repeat runs, and easier to use with different LLM providers.

## Motivation

Local mode previously re-ran the full pipeline every time, even when the source video had already been downloaded and transcribed. It also hard-coded the local LLM path to OpenAI. This change reduces redundant work and makes it easier to use Gemini instead of GPT when running locally.

## What Changed

- Added `LLM_PROVIDER` so local mode can switch between `openai` and `gemini`.
- Added Gemini support to the local LLM backend.
- Allowed local mode to accept a direct file path or `file://` URL, not just YouTube URLs.
- Added download caching for YouTube inputs using `output/source_<youtube_id>.*`.
- Added transcript caching as `.srt` files in `LOCAL_OUTPUT_DIR` and reuse them when the source file has not changed.
- Updated `.env.example`, README, and local dependency requirements to reflect the new behavior.

## Impact

- Faster repeat runs on the same video.
- No need to re-download or re-transcribe when the input has already been processed.
- Easier local experimentation with Gemini.
- Better support for workflows where the video is already on disk.

## Validation

- Ran `python -m py_compile` on the modified Python files.
- Manually tested local mode with file-based inputs and cached runs.

## Notes

- Local downloads are only cached for YouTube URLs; direct file paths are reused as-is.


## Disclaimer

I'm not a Python expert, but I'm sure there will be something to correct in my changes :)
