### PR TITLE
Add optional SenseVoice transcription backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Built for creators, agencies, and developers who don't want to pay $20–$300/mo
 ## Features
 
 - **🎬 YouTube In, Vertical Out**: Hand it any YouTube URL — get back N viral-ready 9:16 mp4s
-- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, and `ffmpeg`/`opencv`, and lets you pick OpenAI or Gemini for highlight ranking
+- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, or optional SenseVoice/FunASR for transcription, plus `ffmpeg`/`opencv`, and lets you pick OpenAI or Gemini for highlight ranking
 - **🤖 Virality-Aware Highlight Selection**: Clips ranked on hooks, emotional peaks, opinion bombs, revelation moments, conflict, quotable lines, story peaks, and practical value — not just generic "interesting"
 - **📈 Score + Hook + Reason for Every Clip**: Each highlight comes with a viral score, an opening hook line, and a one-sentence explanation of why it works
 - **🎤 Whisper Transcription, Your Choice**: Cloud (`/openai-whisper` via MuAPI) or local (`faster-whisper`, CPU or CUDA) — same downstream output shape
@@ -59,6 +59,7 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
 - Python 3.10+
 - For **API mode (default)**: a MuAPI key — powers download, transcription, highlight ranking, and clipping in a single dependency
 - For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an LLM API key (`OPENAI_API_KEY` or `GEMINI_API_KEY`; only the LLM step is remote)
+- Optional faster transcription backend: SenseVoice/FunASR via `LOCAL_ASR_BACKEND=sensevoice`
 
 ### Steps
 
@@ -90,12 +91,14 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
 
    # Local mode (--mode local)
    LLM_PROVIDER=openai         # openai or gemini
+  LOCAL_ASR_BACKEND=whisper   # whisper or sensevoice
    OPENAI_API_KEY=your_openai_key_here
    OPENAI_MODEL=gpt-4o-mini          # optional, default gpt-4o-mini
    GEMINI_API_KEY=your_gemini_key_here
    GEMINI_MODEL=gemini-2.5-flash      # optional, default gemini-2.5-flash
    LOCAL_WHISPER_MODEL=base          # tiny / base / small / medium / large-v3
    LOCAL_WHISPER_DEVICE=auto         # auto / cpu / cuda
+  LOCAL_SENSEVOICE_MODEL=iic/SenseVoiceSmall  # optional, used when LOCAL_ASR_BACKEND=sensevoice
    LOCAL_OUTPUT_DIR=output           # where local mp4s land
    ```
 
@@ -114,6 +117,7 @@ python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local
 ```
 
 Local mode writes the rendered shorts to `./output/short_01.mp4`, `short_02.mp4`, … (override with `LOCAL_OUTPUT_DIR`).
+Set `LOCAL_ASR_BACKEND=sensevoice` to use SenseVoice/FunASR instead of Whisper for the transcription step.
 
 ### With options
 
@@ -181,7 +185,7 @@ xargs -a urls.txt -I{} python main.py "{}"
 | Step | API mode (`--mode api`) | Local mode (`--mode local`) |
 |---|---|---|
 | Download | MuAPI `/youtube-download` | `yt-dlp` for remote URLs, direct file path for local inputs |
-| Transcription | MuAPI `/openai-whisper` | `faster-whisper` (CPU or CUDA) |
+| Transcription | MuAPI `/openai-whisper` | `faster-whisper` (CPU or CUDA) or SenseVoice/FunASR (`LOCAL_ASR_BACKEND=sensevoice`) |
 | Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default) |
 | Vertical crop | MuAPI `/autocrop` | `ffmpeg` + OpenCV face tracking |
 | Output | hosted URLs | local mp4 paths |
@@ -255,6 +259,9 @@ Edit `shorts_generator/config.py` (or set env vars):
 
 ### Whisper transcription
 Audio is transcribed by MuAPI's `/openai-whisper` endpoint (server-side `whisper-1`). Pass `--language <code>` to lock the recognition to a specific language; otherwise it auto-detects.
+
+### Local ASR backend
+Set `LOCAL_ASR_BACKEND=whisper` (default) to use faster-whisper, or `LOCAL_ASR_BACKEND=sensevoice` to use SenseVoice/FunASR with built-in VAD and punctuation. SenseVoice uses `LOCAL_SENSEVOICE_MODEL` (default `iic/SenseVoiceSmall`).
 
 ## Project Structure
 

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -3,8 +3,9 @@
 # Optional dependencies for --mode local.
 yt-dlp>=2024.1.1
 faster-whisper>=1.0.0
+funasr>=1.0.0
 openai>=1.0.0
 google-genai>=1.0.0
 opencv-python>=4.8.0
-# torch is only needed if you want CUDA Whisper. CPU works without it.
+# torch/torchaudio are needed for GPU Whisper or SenseVoice/FunASR.
 # torch>=2.0

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -16,8 +16,10 @@ OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "").strip()
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
+LOCAL_ASR_BACKEND = os.getenv("LOCAL_ASR_BACKEND", "whisper").strip().lower()
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda
+LOCAL_SENSEVOICE_MODEL = os.getenv("LOCAL_SENSEVOICE_MODEL", "iic/SenseVoiceSmall")
 LOCAL_OUTPUT_DIR = os.getenv("LOCAL_OUTPUT_DIR", "output")
 
 

--- a/shorts_generator/local/transcriber.py
+++ b/shorts_generator/local/transcriber.py
@@ -5,17 +5,36 @@ expects: {duration, segments[start, end, text]}.
 """
 import os
 import re
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import Dict, Optional
 
-from ..config import LOCAL_OUTPUT_DIR, LOCAL_WHISPER_DEVICE, LOCAL_WHISPER_MODEL
+from ..config import (
+    LOCAL_ASR_BACKEND,
+    LOCAL_OUTPUT_DIR,
+    LOCAL_SENSEVOICE_MODEL,
+    LOCAL_WHISPER_DEVICE,
+    LOCAL_WHISPER_MODEL,
+)
 
 
-def _transcript_cache_path(media_path: str) -> Path:
+def _resolve_asr_backend() -> str:
+    backend = (LOCAL_ASR_BACKEND or "whisper").strip().lower()
+    if backend in ("whisper", "faster-whisper", "faster_whisper"):
+        return "whisper"
+    if backend in ("sensevoice", "funasr", "fun-asr"):
+        return "sensevoice"
+    raise RuntimeError(
+        f"Unknown LOCAL_ASR_BACKEND={backend!r}. Use 'whisper' or 'sensevoice'."
+    )
+
+
+def _transcript_cache_path(media_path: str, backend: str) -> Path:
     """Return the .srt cache path for a media file."""
     cache_dir = Path(LOCAL_OUTPUT_DIR)
     cache_dir.mkdir(parents=True, exist_ok=True)
-    return cache_dir / (Path(media_path).stem + ".srt")
+    return cache_dir / f"{Path(media_path).stem}.{backend}.srt"
 
 
 def _format_srt_timestamp(seconds: float) -> str:
@@ -35,6 +54,182 @@ def _parse_srt_timestamp(value: str) -> float:
         raise ValueError(f"Invalid SRT timestamp: {value!r}")
     hours, minutes, seconds, millis = map(int, match.groups())
     return hours * 3600 + minutes * 60 + seconds + (millis / 1000.0)
+
+
+def _probe_duration(media_path: str) -> float:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        media_path,
+    ]
+    try:
+        output = subprocess.check_output(cmd, text=True).strip()
+        return float(output)
+    except Exception:
+        return 0.0
+
+
+def _extract_audio_track(source_path: str, output_path: Path) -> None:
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-loglevel",
+        "error",
+        "-i",
+        source_path,
+        "-vn",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-c:a",
+        "pcm_s16le",
+        str(output_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def _seconds(value: object) -> float:
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if seconds > 1000:
+        seconds /= 1000.0
+    return max(0.0, seconds)
+
+
+def _coerce_funasr_result(result: object) -> Dict:
+    if isinstance(result, list) and result:
+        first = result[0]
+        if isinstance(first, dict):
+            return first
+    if isinstance(result, dict):
+        return result
+    return {}
+
+
+def _sentence_info_to_segments(sentence_info: object) -> list:
+    if not isinstance(sentence_info, list):
+        return []
+
+    segments = []
+    for sentence in sentence_info:
+        if not isinstance(sentence, dict):
+            continue
+
+        start = _seconds(sentence.get("start", sentence.get("begin")))
+        end = _seconds(sentence.get("end", sentence.get("stop")))
+        text = str(sentence.get("text") or "").strip()
+        if not text or end <= start:
+            continue
+
+        segments.append({"start": start, "end": end, "text": text})
+
+    return segments
+
+
+def _transcribe_whisper(media_path: str, language: Optional[str] = None) -> Dict:
+    try:
+        from faster_whisper import WhisperModel  # type: ignore
+    except ImportError as e:
+        raise RuntimeError(
+            "faster-whisper is required for --mode local whisper transcription. Install it with:\n"
+            "    pip install -r requirements-local.txt"
+        ) from e
+
+    device = _resolve_device()
+    compute_type = "float16" if device == "cuda" else "int8"
+    print(f"[transcribe/local] whisper model={LOCAL_WHISPER_MODEL} device={device}", flush=True)
+
+    model = WhisperModel(LOCAL_WHISPER_MODEL, device=device, compute_type=compute_type)
+    segments_iter, info = model.transcribe(
+        media_path,
+        language=language,
+        beam_size=5,
+        vad_filter=True,
+        condition_on_previous_text=False,
+    )
+
+    segments = []
+    for s in segments_iter:
+        segments.append({
+            "start": float(s.start),
+            "end": float(s.end),
+            "text": (s.text or "").strip(),
+        })
+
+    duration = float(getattr(info, "duration", 0.0)) or (segments[-1]["end"] if segments else 0.0)
+    print(f"[transcribe/local] {len(segments)} segments, {duration:.0f}s of audio", flush=True)
+    return {"duration": duration, "segments": segments}
+
+
+def _transcribe_sensevoice(media_path: str, language: Optional[str] = None) -> Dict:
+    try:
+        from funasr import AutoModel  # type: ignore
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess  # type: ignore
+    except ImportError as e:
+        raise RuntimeError(
+            "funasr is required for --mode local when LOCAL_ASR_BACKEND=sensevoice. Install it with:\n"
+            "    pip install -r requirements-local.txt"
+        ) from e
+
+    device = _resolve_device()
+    sensevoice_device = "cuda:0" if device == "cuda" else device
+    print(
+        f"[transcribe/local] sensevoice model={LOCAL_SENSEVOICE_MODEL} device={sensevoice_device}",
+        flush=True,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="sensevoice-") as tmpdir:
+        audio_path = Path(tmpdir) / f"{Path(media_path).stem}.wav"
+        _extract_audio_track(media_path, audio_path)
+
+        model = AutoModel(
+            model=LOCAL_SENSEVOICE_MODEL,
+            trust_remote_code=True,
+            vad_model="fsmn-vad",
+            vad_kwargs={"max_single_segment_time": 30000},
+            punc_model="ct-punc",
+            device=sensevoice_device,
+        )
+        result = model.generate(
+            input=str(audio_path),
+            cache={},
+            language=(language or "auto"),
+            use_itn=True,
+            batch_size_s=60,
+            merge_vad=True,
+            merge_length_s=15,
+        )
+
+    payload = _coerce_funasr_result(result)
+    segments = _sentence_info_to_segments(payload.get("sentence_info"))
+    if not segments:
+        segments = _sentence_info_to_segments(payload.get("timestamp"))
+
+    if not segments:
+        text = rich_transcription_postprocess(str(payload.get("text") or "").strip())
+        duration = _probe_duration(media_path)
+        if text and duration > 0:
+            segments = [{"start": 0.0, "end": duration, "text": text}]
+
+    duration = _probe_duration(media_path)
+    if not duration and segments:
+        duration = segments[-1]["end"]
+
+    print(f"[transcribe/local] {len(segments)} segments, {duration:.0f}s of audio", flush=True)
+    if not segments:
+        raise RuntimeError(
+            "SenseVoice returned no usable sentence timestamps. Try another model or backend."
+        )
+
+    return {"duration": duration, "segments": segments}
 
 
 def _write_srt_cache(media_path: str, transcript: Dict) -> Path:
@@ -92,8 +287,9 @@ def _resolve_device() -> str:
 
 
 def transcribe_local(media_path: str, language: Optional[str] = None) -> Dict:
-    """Run faster-whisper on a local file path, caching the result as .srt."""
-    cache_path = _transcript_cache_path(media_path)
+    """Run the configured local ASR backend on a file path and cache as .srt."""
+    backend = _resolve_asr_backend()
+    cache_path = _transcript_cache_path(media_path, backend)
     if cache_path.exists():
         source_mtime = os.path.getmtime(media_path)
         cache_mtime = cache_path.stat().st_mtime
@@ -107,38 +303,7 @@ def transcribe_local(media_path: str, language: Optional[str] = None) -> Dict:
             )
             return cached
 
-    try:
-        from faster_whisper import WhisperModel  # type: ignore
-    except ImportError as e:
-        raise RuntimeError(
-            "faster-whisper is required for --mode local. Install it with:\n"
-            "    pip install -r requirements-local.txt"
-        ) from e
-
-    device = _resolve_device()
-    compute_type = "float16" if device == "cuda" else "int8"
-    print(f"[transcribe/local] faster-whisper model={LOCAL_WHISPER_MODEL} device={device}", flush=True)
-
-    model = WhisperModel(LOCAL_WHISPER_MODEL, device=device, compute_type=compute_type)
-    segments_iter, info = model.transcribe(
-        media_path,
-        language=language,
-        beam_size=5,
-        vad_filter=True,
-        condition_on_previous_text=False,
-    )
-
-    segments = []
-    for s in segments_iter:
-        segments.append({
-            "start": float(s.start),
-            "end": float(s.end),
-            "text": (s.text or "").strip(),
-        })
-
-    duration = float(getattr(info, "duration", 0.0)) or (segments[-1]["end"] if segments else 0.0)
-    print(f"[transcribe/local] {len(segments)} segments, {duration:.0f}s of audio", flush=True)
-    transcript = {"duration": duration, "segments": segments}
+    transcript = _transcribe_whisper(media_path, language=language) if backend == "whisper" else _transcribe_sensevoice(media_path, language=language)
     cache_path = _write_srt_cache(media_path, transcript)
     print(f"[transcribe/local] wrote cache: {cache_path}", flush=True)
     return transcript


### PR DESCRIPTION
## What this adds

This patch makes local transcription backend-pluggable by adding an optional SenseVoice/FunASR path alongside the existing Whisper-based implementation.

## Why this matters

Local mode already owns the transcription step. Giving contributors a second backend lets them compare speed and quality tradeoffs without touching the rest of the shorts pipeline, while keeping Whisper as the default for backwards compatibility.

## Implementation

- Adds `LOCAL_ASR_BACKEND` with `whisper` as the default
- Adds a SenseVoice/FunASR transcription path that returns the same segment shape as the Whisper implementation
- Keeps transcript caching backend-aware so transcripts do not clash between backends
- Updates the README and local dependency list so the new option is discoverable

## Validation

- `python -m py_compile shorts_generator/local/transcriber.py shorts_generator/config.py`
- `git diff --check`
- GitNexus `detect-changes` run completed with medium-risk scope

## Compatibility

Whisper remains the default backend. Existing local-mode users do not need to change anything unless they explicitly set `LOCAL_ASR_BACKEND=sensevoice`.