### PR TITLE
feat(local): add TwelveLabs Pegasus video-understanding highlight provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,18 @@
 MUAPI_API_KEY=your_muapi_key_here
 
 # Local mode (--mode local)
-LLM_PROVIDER=openai           # openai or gemini
+LLM_PROVIDER=openai           # openai, gemini, or twelvelabs
 OPENAI_API_KEY=your_openai_key_here
 OPENAI_MODEL=gpt-4o-mini
 GEMINI_API_KEY=your_gemini_key_here
 GEMINI_MODEL=gemini-2.5-flash
+
+# TwelveLabs Pegasus (LLM_PROVIDER=twelvelabs) — ranks highlights from the video
+# itself, not just the transcript. Free key: https://twelvelabs.io
+TWELVELABS_API_KEY=your_twelvelabs_key_here
+TWELVELABS_PEGASUS_MODEL=pegasus1.5
+TWELVELABS_INDEX_ID=          # optional: reuse an existing index; auto-created if blank
+TWELVELABS_MAX_TOKENS=2048
 LOCAL_WHISPER_MODEL=base
 LOCAL_WHISPER_DEVICE=auto
 LOCAL_OUTPUT_DIR=output

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Built for creators, agencies, and developers who don't want to pay $20–$300/mo
 ## Features
 
 - **🎬 YouTube In, Vertical Out**: Hand it any YouTube URL — get back N viral-ready 9:16 mp4s
-- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, and `ffmpeg`/`opencv`, and lets you pick OpenAI or Gemini for highlight ranking
+- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, and `ffmpeg`/`opencv`, and lets you pick OpenAI, Gemini, or TwelveLabs Pegasus for highlight ranking
+- **🎥 Optional Video-Understanding Highlights (TwelveLabs Pegasus)**: Set `LLM_PROVIDER=twelvelabs` in local mode and Pegasus *watches the video* to pick highlights — catching visual gags, reactions, pacing, and on-screen text that a transcript-only LLM misses
 - **🤖 Virality-Aware Highlight Selection**: Clips ranked on hooks, emotional peaks, opinion bombs, revelation moments, conflict, quotable lines, story peaks, and practical value — not just generic "interesting"
 - **📈 Score + Hook + Reason for Every Clip**: Each highlight comes with a viral score, an opening hook line, and a one-sentence explanation of why it works
 - **🎤 Whisper Transcription, Your Choice**: Cloud (`/openai-whisper` via MuAPI) or local (`faster-whisper`, CPU or CUDA) — same downstream output shape
@@ -92,11 +93,15 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
    MUAPI_API_KEY=your_muapi_key_here
 
    # Local mode (--mode local)
-   LLM_PROVIDER=openai         # openai or gemini
+   LLM_PROVIDER=openai         # openai, gemini, or twelvelabs
    OPENAI_API_KEY=your_openai_key_here
    OPENAI_MODEL=gpt-4o-mini          # optional, default gpt-4o-mini
    GEMINI_API_KEY=your_gemini_key_here
    GEMINI_MODEL=gemini-2.5-flash      # optional, default gemini-2.5-flash
+   # TwelveLabs Pegasus (LLM_PROVIDER=twelvelabs) — free key at https://twelvelabs.io
+   TWELVELABS_API_KEY=your_twelvelabs_key_here
+   TWELVELABS_PEGASUS_MODEL=pegasus1.5   # optional, default pegasus1.5
+   TWELVELABS_INDEX_ID=                  # optional: reuse an index; auto-created if blank
    LOCAL_WHISPER_MODEL=base          # tiny / base / small / medium / large-v3
    LOCAL_WHISPER_DEVICE=auto         # auto / cpu / cuda
    LOCAL_OUTPUT_DIR=output           # where local mp4s land
@@ -185,10 +190,34 @@ xargs -a urls.txt -I{} python main.py "{}"
 |---|---|---|
 | Download | MuAPI `/youtube-download` | `yt-dlp` for remote URLs, direct file path for local inputs |
 | Transcription | MuAPI `/openai-whisper` | `faster-whisper` (CPU or CUDA) |
-| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default) |
+| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default), `LLM_PROVIDER=twelvelabs` uses TwelveLabs Pegasus (`pegasus1.5`) to rank highlights from the video itself |
 | Vertical crop | MuAPI `/autocrop` | `ffmpeg` + OpenCV face tracking |
 | Output | hosted URLs | local mp4 paths |
 | Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY` or `GEMINI_API_KEY` (+ `ffmpeg` on PATH) |
+
+### Video-understanding highlights with TwelveLabs Pegasus
+
+By default, highlight ranking reads the **transcript**. Set `LLM_PROVIDER=twelvelabs`
+in local mode and the ranking step is handled by [TwelveLabs](https://twelvelabs.io)
+Pegasus, a video-understanding model that **watches the video** while it answers the
+same virality prompt — so it can pick up visual gags, facial reactions, pacing, and
+on-screen text that a transcript-only LLM never sees.
+
+```bash
+# .env
+LLM_PROVIDER=twelvelabs
+TWELVELABS_API_KEY=your_key   # free tier at https://twelvelabs.io
+```
+
+```bash
+python main.py "/Users/you/Videos/input.mp4" --mode local
+```
+
+On the first run the source video is uploaded and indexed once (this is the slow
+part); the resulting TwelveLabs video id is cached next to the file as
+`<video>.tlvideo`, so re-runs skip re-indexing. Set `TWELVELABS_INDEX_ID` to reuse
+an existing index instead of auto-creating one. This provider is fully opt-in —
+the default pipeline (MuAPI / OpenAI / Gemini) is unchanged.
 
 ## How It Works
 
@@ -279,6 +308,7 @@ AI-Youtube-Shorts-Generator/
         ├── downloader.py         yt-dlp download
         ├── transcriber.py        faster-whisper transcription
         ├── llm.py                OpenAI or Gemini client selector
+        ├── twelvelabs_provider.py  TwelveLabs Pegasus video-understanding highlights (opt-in)
         └── clipper.py            ffmpeg cut + OpenCV vertical crop
 ```
 

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -5,6 +5,7 @@ yt-dlp>=2024.1.1
 faster-whisper>=1.0.0
 openai>=1.0.0
 google-genai>=1.0.0
+twelvelabs>=1.2.8     # only needed for LLM_PROVIDER=twelvelabs (Pegasus video-understanding highlights)
 opencv-python>=4.8.0
 # torch is only needed if you want CUDA Whisper. CPU works without it.
 # torch>=2.0

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -15,6 +15,14 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "").strip()
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+
+# TwelveLabs Pegasus (LLM_PROVIDER=twelvelabs) — video-understanding highlight
+# ranking: Pegasus watches the video instead of only reading the transcript.
+TWELVELABS_API_KEY = os.getenv("TWELVELABS_API_KEY", "").strip()
+TWELVELABS_PEGASUS_MODEL = os.getenv("TWELVELABS_PEGASUS_MODEL", "pegasus1.5")
+TWELVELABS_INDEX_ID = os.getenv("TWELVELABS_INDEX_ID", "").strip()  # reuse an existing index; auto-created if blank
+TWELVELABS_MAX_TOKENS = int(os.getenv("TWELVELABS_MAX_TOKENS", "2048"))
+
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda
@@ -65,3 +73,13 @@ def require_gemini_key() -> str:
             "Add it to your .env or export it, or switch LLM_PROVIDER back to openai."
         )
     return GEMINI_API_KEY
+
+
+def require_twelvelabs_key() -> str:
+    if not TWELVELABS_API_KEY:
+        raise RuntimeError(
+            "TWELVELABS_API_KEY is not set. Local mode needs a TwelveLabs key when "
+            "LLM_PROVIDER=twelvelabs. Add it to your .env or export it, or switch "
+            "LLM_PROVIDER back to openai. Grab a free key at https://twelvelabs.io."
+        )
+    return TWELVELABS_API_KEY

--- a/shorts_generator/local/twelvelabs_provider.py
+++ b/shorts_generator/local/twelvelabs_provider.py
@@ -1,0 +1,93 @@
+"""TwelveLabs Pegasus highlight backend for --mode local.
+
+Unlike the OpenAI / Gemini backends (which rank the *transcript text*), Pegasus
+is a video-understanding model: it watches the actual video and answers the
+same virality prompt with knowledge of what's on screen — pacing, reactions,
+visual gags, on-screen text — not just the words that were spoken. That makes
+it a multimodal upgrade to the highlight selection step.
+
+Selected by setting ``LLM_PROVIDER=twelvelabs`` in ``--mode local``. Because
+Pegasus needs the video (not just a prompt string), the pipeline binds the
+source video path with ``functools.partial`` before handing the resulting
+``(prompt) -> str`` callable to ``get_highlights``.
+
+Index reuse: the source video is uploaded once and cached on disk next to the
+mp4 as ``<video>.tlvideo`` (the TwelveLabs video id), so re-running the
+pipeline on the same file skips the (slow) re-index.
+"""
+import os
+from pathlib import Path
+
+from ..config import (
+    TWELVELABS_INDEX_ID,
+    TWELVELABS_PEGASUS_MODEL,
+    TWELVELABS_MAX_TOKENS,
+    require_twelvelabs_key,
+)
+
+
+def _import_sdk():
+    try:
+        from twelvelabs import TwelveLabs  # type: ignore
+    except ImportError as e:
+        raise RuntimeError(
+            "twelvelabs is required for LLM_PROVIDER=twelvelabs. Install it with:\n"
+            "    pip install -r requirements-local.txt"
+        ) from e
+    return TwelveLabs
+
+
+def _ensure_index(client) -> str:
+    """Return a Pegasus-enabled index id, creating one if not configured."""
+    if TWELVELABS_INDEX_ID:
+        return TWELVELABS_INDEX_ID
+    index = client.indexes.create(
+        index_name="ai-youtube-shorts-generator",
+        models=[{"model_name": TWELVELABS_PEGASUS_MODEL, "model_options": ["visual", "audio"]}],
+    )
+    return index.id
+
+
+def _cached_video_id(video_path: str) -> str:
+    """Index the video once; cache the resulting video id beside the file."""
+    cache = Path(f"{video_path}.tlvideo")
+    if cache.exists():
+        cached = cache.read_text().strip()
+        if cached:
+            print(f"[twelvelabs] reusing indexed video {cached}", flush=True)
+            return cached
+
+    TwelveLabs = _import_sdk()
+    client = TwelveLabs(api_key=require_twelvelabs_key())
+    index_id = _ensure_index(client)
+
+    print(f"[twelvelabs] indexing {os.path.basename(video_path)} (index {index_id})", flush=True)
+    with open(video_path, "rb") as f:
+        task = client.tasks.create(index_id=index_id, video_file=f)
+    task = client.tasks.wait_for_done(task_id=task.id)
+    if task.status != "ready":
+        raise RuntimeError(f"TwelveLabs indexing failed (status={task.status})")
+
+    video_id = task.video_id
+    cache.write_text(video_id)
+    print(f"[twelvelabs] indexed → video {video_id}", flush=True)
+    return video_id
+
+
+def call_twelvelabs_llm(prompt: str, *, video_path: str) -> str:
+    """Pegasus backend: analyze the video with the highlight prompt.
+
+    ``get_highlights`` calls this as a ``(prompt) -> str`` function; the
+    ``video_path`` is bound by the pipeline via ``functools.partial``.
+    """
+    video_id = _cached_video_id(video_path)
+
+    TwelveLabs = _import_sdk()
+    client = TwelveLabs(api_key=require_twelvelabs_key())
+    result = client.analyze(
+        model_name=TWELVELABS_PEGASUS_MODEL,
+        video_id=video_id,
+        prompt=prompt,
+        max_tokens=TWELVELABS_MAX_TOKENS,
+    )
+    return result.data or ""

--- a/shorts_generator/pipeline.py
+++ b/shorts_generator/pipeline.py
@@ -21,6 +21,9 @@ def _run_local(
     download_format: str,
     language: Optional[str],
 ) -> Dict:
+    from functools import partial
+
+    from .config import LLM_PROVIDER
     from .local.clipper import crop_highlights_local
     from .local.downloader import download_youtube_local
     from .local.llm import call_local_llm
@@ -34,7 +37,16 @@ def _run_local(
             "Whisper produced no segments. The video may have no detectable speech."
         )
 
-    highlights_result = get_highlights(transcript, num_clips=num_clips, llm_fn=call_local_llm)
+    # TwelveLabs Pegasus ranks highlights from the video itself, so it needs the
+    # source path bound in; OpenAI / Gemini only see the transcript prompt.
+    if LLM_PROVIDER == "twelvelabs":
+        from .local.twelvelabs_provider import call_twelvelabs_llm
+
+        llm_fn = partial(call_twelvelabs_llm, video_path=source_path)
+    else:
+        llm_fn = call_local_llm
+
+    highlights_result = get_highlights(transcript, num_clips=num_clips, llm_fn=llm_fn)
     all_highlights: List[Dict] = highlights_result.get("highlights", [])
     if not all_highlights:
         raise RuntimeError("Highlight generator returned zero clips.")

--- a/tests/test_twelvelabs_provider.py
+++ b/tests/test_twelvelabs_provider.py
@@ -1,0 +1,128 @@
+"""Tests for the TwelveLabs Pegasus highlight backend.
+
+* The unit test runs with no network and no SDK — it stubs the TwelveLabs
+  client and asserts the provider indexes the video once, caches the video id,
+  and forwards the prompt to Pegasus's ``analyze``.
+* The live test is skipped unless ``TWELVELABS_API_KEY`` is set; it confirms
+  the SDK + credentials are wired by making a real Marengo embedding call
+  (cheap and fast, unlike a full Pegasus video index).
+"""
+import os
+import sys
+import types
+
+import pytest
+
+
+def _install_fake_sdk(monkeypatch, recorder):
+    """Inject a fake ``twelvelabs`` module so the provider runs offline."""
+
+    class FakeTask:
+        id = "task_1"
+        status = "ready"
+        video_id = "vid_123"
+
+    class FakeTasks:
+        def create(self, *, index_id, video_file):
+            recorder["index_id"] = index_id
+            recorder["uploaded"] = True
+            return FakeTask()
+
+        def wait_for_done(self, *, task_id):
+            return FakeTask()
+
+    class FakeIndex:
+        id = "idx_new"
+
+    class FakeIndexes:
+        def create(self, *, index_name, models):
+            recorder["created_index"] = (index_name, models)
+            return FakeIndex()
+
+    class FakeResult:
+        data = '{"highlights": []}'
+
+    class FakeClient:
+        def __init__(self, *, api_key):
+            recorder["api_key"] = api_key
+            self.tasks = FakeTasks()
+            self.indexes = FakeIndexes()
+
+        def analyze(self, *, model_name, video_id, prompt, max_tokens):
+            recorder["analyze"] = {
+                "model_name": model_name,
+                "video_id": video_id,
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+            }
+            return FakeResult()
+
+    fake_mod = types.ModuleType("twelvelabs")
+    fake_mod.TwelveLabs = FakeClient
+    monkeypatch.setitem(sys.modules, "twelvelabs", fake_mod)
+
+
+def test_provider_indexes_once_and_calls_pegasus(tmp_path, monkeypatch):
+    monkeypatch.setenv("TWELVELABS_API_KEY", "test-key")
+    monkeypatch.setenv("TWELVELABS_INDEX_ID", "")  # force auto-create
+
+    # config reads env at import time; reload it after setting env.
+    import importlib
+
+    from shorts_generator import config
+    importlib.reload(config)
+    from shorts_generator.local import twelvelabs_provider
+    importlib.reload(twelvelabs_provider)
+
+    recorder: dict = {}
+    _install_fake_sdk(monkeypatch, recorder)
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not-a-real-mp4")
+
+    out = twelvelabs_provider.call_twelvelabs_llm("rank highlights", video_path=str(video))
+
+    assert out == '{"highlights": []}'
+    assert recorder["api_key"] == "test-key"
+    assert recorder["uploaded"] is True
+    assert recorder["created_index"][0] == "ai-youtube-shorts-generator"
+    assert recorder["analyze"]["video_id"] == "vid_123"
+    assert recorder["analyze"]["model_name"] == "pegasus1.5"
+    assert recorder["analyze"]["prompt"] == "rank highlights"
+
+    # Video id cached beside the file → a second call skips re-indexing.
+    cache = video.with_suffix(".mp4.tlvideo")
+    assert cache.read_text() == "vid_123"
+
+    recorder.clear()
+    _install_fake_sdk(monkeypatch, recorder)
+    twelvelabs_provider.call_twelvelabs_llm("again", video_path=str(video))
+    assert "uploaded" not in recorder  # reused cache, no re-upload
+    assert recorder["analyze"]["video_id"] == "vid_123"
+
+
+def test_missing_key_raises(monkeypatch):
+    monkeypatch.setenv("TWELVELABS_API_KEY", "")
+    import importlib
+
+    from shorts_generator import config
+    importlib.reload(config)
+    with pytest.raises(RuntimeError, match="TWELVELABS_API_KEY"):
+        config.require_twelvelabs_key()
+
+
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="set TWELVELABS_API_KEY to run the live TwelveLabs smoke test",
+)
+def test_live_credentials_and_sdk():
+    """Cheap live check: Marengo text embedding returns a 512-dim vector."""
+    from twelvelabs import TwelveLabs
+
+    client = TwelveLabs(api_key=os.environ["TWELVELABS_API_KEY"])
+    resp = client.embed.create(
+        model_name="marengo3.0",
+        text="a person laughing at a surprising revelation",
+    )
+    vector = resp.text_embedding.segments[0].float_
+    assert len(vector) == 512


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

A third, fully opt-in highlight-ranking backend for `--mode local`: set `LLM_PROVIDER=twelvelabs` and the highlight selection step is handled by [TwelveLabs](https://twelvelabs.io) **Pegasus**, a video-understanding model.

The existing OpenAI / Gemini backends rank the **transcript text**. Pegasus instead **watches the actual video** while answering the very same virality prompt (`HIGHLIGHT_SYSTEM_PROMPT` in `highlights.py`), so it can catch the signals a transcript can't see — visual gags, facial reactions, pacing, B-roll, and on-screen text. For short-form clipping, those visual cues are often exactly what makes a moment go viral.

## Why it helps this project

The repo already frames highlight ranking as a pluggable `llm_fn` and advertises "full control over the highlight algorithm." This extends that control to multimodal selection without changing the output shape — same `{title, start_time, end_time, score, hook_sentence, virality_reason}` schema flows into the existing dedupe + crop steps untouched.

## Opt-in / non-breaking

- Default mode (`--mode api`, MuAPI) and the existing local OpenAI/Gemini paths are **completely unchanged**.
- Pegasus only runs when `LLM_PROVIDER=twelvelabs` is explicitly set.
- The `twelvelabs` SDK is an optional dependency (added to `requirements-local.txt`), lazily imported with a clear install hint if missing — mirroring how `openai` / `google-genai` are handled.
- The source video is indexed once and the video id cached beside the file (`<video>.tlvideo`), so re-runs skip the slow re-index. `TWELVELABS_INDEX_ID` lets you reuse an existing index.

## Files

- `shorts_generator/local/twelvelabs_provider.py` — new provider (mirrors `local/llm.py`)
- `shorts_generator/config.py` — `TWELVELABS_*` settings + `require_twelvelabs_key()`
- `shorts_generator/pipeline.py` — dispatch to Pegasus in `_run_local` (binds the video path via `functools.partial`, since Pegasus needs the video, not just the prompt)
- `requirements-local.txt`, `.env.example`, `README.md` — deps + docs
- `tests/test_twelvelabs_provider.py` — tests

## How it was tested

- `pytest tests/` — 3 passing:
  - **offline unit test** (stubbed SDK, no network): asserts the video is indexed once, the video id is cached, re-runs skip re-upload, and the prompt + `pegasus1.5` reach `analyze`.
  - **missing-key** test: `require_twelvelabs_key()` raises a helpful error.
  - **live test** (gated on `TWELVELABS_API_KEY`, skipped otherwise): a real Marengo text-embedding call returns a 512-dim vector, confirming SDK + credentials wiring.
- Verified every method/attribute used (`tasks.create`, `tasks.wait_for_done`, `.status`, `.video_id`, `analyze(..).data`) against the installed `twelvelabs==1.2.8` SDK.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.