### PR TITLE
Add Ollama as local/cloud LLM options, shot aware mode, captions, clip length target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,16 @@
 MUAPI_API_KEY=your_muapi_key_here
 
 # Local mode (--mode local)
-LLM_PROVIDER=openai           # openai or gemini
+LLM_PROVIDER=openai           # openai, gemini, or ollama
 OPENAI_API_KEY=your_openai_key_here
 OPENAI_MODEL=gpt-4o-mini
 GEMINI_API_KEY=your_gemini_key_here
 GEMINI_MODEL=gemini-2.5-flash
+
+# Ollama settings (when LLM_PROVIDER=ollama)
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llama3.2
+
 LOCAL_WHISPER_MODEL=base
 LOCAL_WHISPER_DEVICE=auto
 LOCAL_OUTPUT_DIR=output

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ OLLAMA_MODEL=llama3.2
 LOCAL_WHISPER_MODEL=base
 LOCAL_WHISPER_DEVICE=auto
 LOCAL_OUTPUT_DIR=output
+
+# Optional: target clip length in seconds (±5s tolerance). Leave unset for the original 45-90s sweet spot.
+# CLIP_LENGTH=45

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ GEMINI_MODEL=gemini-2.5-flash
 # Ollama settings (when LLM_PROVIDER=ollama)
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.2
+# Context window size in tokens (default 32768; lower if you run out of VRAM)
+# OLLAMA_NUM_CTX=32768
 
 LOCAL_WHISPER_MODEL=base
 LOCAL_WHISPER_DEVICE=auto

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
    # Ollama settings (when LLM_PROVIDER=ollama)
    OLLAMA_BASE_URL=http://localhost:11434   # local or remote Ollama endpoint
    OLLAMA_MODEL=llama3.2                    # any model pulled in Ollama
+   # OLLAMA_NUM_CTX=32768                   # context window size in tokens (default 32768)
+   # CLIP_LENGTH=45                         # optional: target clip length in seconds (±5s tolerance)
    LOCAL_WHISPER_MODEL=base          # tiny / base / small / medium / large-v3
    LOCAL_WHISPER_DEVICE=auto         # auto / cpu / cuda
    LOCAL_OUTPUT_DIR=output           # where local mp4s land
@@ -201,6 +203,7 @@ xargs -a urls.txt -I{} python main.py "{}"
 |------|---------|-------|
 | `--mode` | `api` | `api` (MuAPI, fast, no setup) or `local` (remote URL, `file://`, or local path + faster-whisper + LLM provider + ffmpeg) |
 | `--num-clips` | `3` | How many shorts to render |
+| `--clip-length` | — | Optional: target clip length in seconds (±5s tolerance). Default behavior is 45–90s sweet spot |
 | `--aspect-ratio` | `9:16` | Any ratio; `9:16` for TikTok/Reels, `1:1` for square |
 | `--format` | `720` | Source download resolution: `360` / `480` / `720` / `1080` |
 | `--language` | auto | Force Whisper language code (e.g. `en`) |
@@ -328,6 +331,23 @@ If you don't have a local GPU, you can point `OLLAMA_BASE_URL` at:
 - **RunPod** Serverless or Pod with Ollama pre-installed
 - **Vast.ai** — rent an RTX 3090/4090 by the hour (~$0.30–$0.60/hr)
 - **AnyScale Endpoints** or **Together AI** — OpenAI-compatible APIs that serve open-weight models (set `LLM_PROVIDER=openai` and point `OPENAI_BASE_URL` at their endpoint)
+
+### Clip length
+
+By default the LLM uses a **45–90 second** sweet spot for highlights, which works well for most content. If you want tighter control, set `CLIP_LENGTH` (in seconds) and the LLM will aim for that length with a ±5-second tolerance. A value of `30` produces 25–35s clips and `10` produces 5–15s clips.
+
+```bash
+# .env
+CLIP_LENGTH=30
+```
+
+Or pass it per-run:
+
+```bash
+python main.py "..." --mode local --clip-length 30
+```
+
+Shorter values (10–20) are great for quick hooks; longer values (60–90) suit tutorials or story arcs. Leave it unset to keep the original 45–90s behavior.
 
 ### Highlight selection criteria
 Edit `shorts_generator/highlights.py`:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local
 
 Local mode writes the rendered shorts to `./output/short_01.mp4`, `short_02.mp4`, … (override with `LOCAL_OUTPUT_DIR`).
 
+### Shot-aware cropping (local mode)
+
+When your video has distinct camera cuts or angle changes (e.g. switching between wide shots, close-ups, and different subjects), the default face-tracking crop can drift or shake as it adjusts mid-shot. Use `--crop-mode shot` to detect shot boundaries and lock the crop center to the main action area within each shot:
+
+```bash
+python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local --crop-mode shot
+```
+
+This analyzes motion per shot, finds where the most activity happens, and keeps the crop locked there until the next cut. No mid-shot drift — ideal for stationary shots where you want the action centered per scene.
+
 ### With options
 
 ```bash
@@ -180,6 +190,7 @@ xargs -a urls.txt -I{} python main.py "{}"
 | `--aspect-ratio` | `9:16` | Any ratio; `9:16` for TikTok/Reels, `1:1` for square |
 | `--format` | `720` | Source download resolution: `360` / `480` / `720` / `1080` |
 | `--language` | auto | Force Whisper language code (e.g. `en`) |
+| `--crop-mode` | `face` | Local mode only: `face` (face-tracking) or `shot` (shot-aware action centering) |
 | `--output-json` | — | Dump the full result (transcript + all candidates) to a file |
 
 ### API mode vs Local mode

--- a/README.md
+++ b/README.md
@@ -92,11 +92,14 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
    MUAPI_API_KEY=your_muapi_key_here
 
    # Local mode (--mode local)
-   LLM_PROVIDER=openai         # openai or gemini
+   LLM_PROVIDER=openai         # openai, gemini, or ollama
    OPENAI_API_KEY=your_openai_key_here
    OPENAI_MODEL=gpt-4o-mini          # optional, default gpt-4o-mini
    GEMINI_API_KEY=your_gemini_key_here
    GEMINI_MODEL=gemini-2.5-flash      # optional, default gemini-2.5-flash
+   # Ollama settings (when LLM_PROVIDER=ollama)
+   OLLAMA_BASE_URL=http://localhost:11434   # local or remote Ollama endpoint
+   OLLAMA_MODEL=llama3.2                    # any model pulled in Ollama
    LOCAL_WHISPER_MODEL=base          # tiny / base / small / medium / large-v3
    LOCAL_WHISPER_DEVICE=auto         # auto / cpu / cuda
    LOCAL_OUTPUT_DIR=output           # where local mp4s land
@@ -185,10 +188,10 @@ xargs -a urls.txt -I{} python main.py "{}"
 |---|---|---|
 | Download | MuAPI `/youtube-download` | `yt-dlp` for remote URLs, direct file path for local inputs |
 | Transcription | MuAPI `/openai-whisper` | `faster-whisper` (CPU or CUDA) |
-| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default) |
+| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default), `LLM_PROVIDER=ollama` uses any Ollama model (local or remote) |
 | Vertical crop | MuAPI `/autocrop` | `ffmpeg` + OpenCV face tracking |
 | Output | hosted URLs | local mp4 paths |
-| Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY` or `GEMINI_API_KEY` (+ `ffmpeg` on PATH) |
+| Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY`, `GEMINI_API_KEY`, or Ollama endpoint (+ `ffmpeg` on PATH) |
 
 ## How It Works
 
@@ -243,6 +246,49 @@ Highlights:    7 candidates → kept top 3
 
 ## Configuration
 
+### Ollama (fully local / self-hosted LLM)
+
+Set `LLM_PROVIDER=ollama` to run highlight ranking through any Ollama-compatible endpoint — your laptop, a LAN server, or a cloud GPU instance (RunPod, Vast.ai, etc.).
+
+1. **Install Ollama** (if running locally): https://ollama.com/download
+2. **Pull a model** (see model recommendations below):
+   ```bash
+   ollama pull llama3.2
+   ```
+3. **Configure `.env`**:
+   ```bash
+   LLM_PROVIDER=ollama
+   OLLAMA_BASE_URL=http://localhost:11434
+   OLLAMA_MODEL=llama3.2
+   ```
+4. **Run**:
+   ```bash
+   python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local
+   ```
+
+**Remote Ollama example** (e.g. on a cloud GPU):
+```bash
+OLLAMA_BASE_URL=http://192.168.1.50:11434 OLLAMA_MODEL=phi4 python main.py "..." --mode local
+```
+
+**Recommended models for an 8 GB GPU**
+
+| Model | Size | Notes |
+|-------|------|-------|
+| `llama3.2` | 3B | Fast, good instruction following, fits easily on 8 GB |
+| `phi4` | ~14B (Q4_K_M ≈ 8.5 GB) | Strong reasoning; may need `--num_gpu 1` on 8 GB |
+| `qwen2.5` | 7B (Q4 ≈ 4.5 GB) | Excellent multilingual, great JSON adherence |
+| `gemma3` | 4B (Q4 ≈ 3 GB) | Google's lightweight model, solid quality |
+| `mistral` | 7B (Q4 ≈ 4.1 GB) | Good general performance, fast inference |
+| `deepseek-r1:7b` | 7B (Q4 ≈ 4.5 GB) | Reasoning-focused, slower but thorough |
+
+**Cloud / hosted Ollama options**
+
+If you don't have a local GPU, you can point `OLLAMA_BASE_URL` at:
+- **RunPod** Serverless or Pod with Ollama pre-installed
+- **Vast.ai** — rent an RTX 3090/4090 by the hour (~$0.30–$0.60/hr)
+- **AnyScale Endpoints** or **Together AI** — OpenAI-compatible APIs that serve open-weight models (set `LLM_PROVIDER=openai` and point `OPENAI_BASE_URL` at their endpoint)
+
 ### Highlight selection criteria
 Edit `shorts_generator/highlights.py`:
 - **Virality framework**: `VIRALITY_CRITERIA` — the ranked list of signals the LLM optimizes for
@@ -278,7 +324,7 @@ AI-Youtube-Shorts-Generator/
     └── local/                    --mode local backends (offline)
         ├── downloader.py         yt-dlp download
         ├── transcriber.py        faster-whisper transcription
-        ├── llm.py                OpenAI or Gemini client selector
+        ├── llm.py                OpenAI / Gemini / Ollama client selector
         └── clipper.py            ffmpeg cut + OpenCV vertical crop
 ```
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ xargs -a urls.txt -I{} python main.py "{}"
 | `--language` | auto | Force Whisper language code (e.g. `en`) |
 | `--crop-mode` | `face` | Local mode only: `face` (face-tracking) or `shot` (shot-aware action centering) |
 | `--captions` | off | Local mode only: burn transcript captions into the output clips |
+| `--generate-metadata` | off | Generate YouTube + TikTok titles, descriptions, and hashtags for each short |
 | `--output-json` | — | Dump the full result (transcript + all candidates) to a file |
 
 ### API mode vs Local mode
@@ -348,6 +349,22 @@ python main.py "..." --mode local --clip-length 30
 ```
 
 Shorter values (10–20) are great for quick hooks; longer values (60–90) suit tutorials or story arcs. Leave it unset to keep the original 45–90s behavior.
+
+### Metadata generation
+
+Generate platform-specific titles and descriptions for each short by passing `--generate-metadata`:
+
+```bash
+python main.py "..." --mode local --generate-metadata
+```
+
+This produces a `shorts_metadata.txt` file alongside the clips with:
+- **YouTube title** (max 60 chars)
+- **YouTube description** (2–3 sentences + hashtags)
+- **TikTok caption** (max 100 chars, emoji-friendly)
+- **TikTok hashtags** (5–8 relevant tags)
+
+The metadata is grounded in the clip's actual transcript, hook sentence, and virality reason. Default is off to save LLM tokens and time.
 
 ### Highlight selection criteria
 Edit `shorts_generator/highlights.py`:

--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local --crop-mo
 
 This analyzes motion per shot, finds where the most activity happens, and keeps the crop locked there until the next cut. No mid-shot drift — ideal for stationary shots where you want the action centered per scene.
 
+### Captions (local mode)
+
+Burn transcript captions directly into the output clips. White text with a black outline, bottom-centered, sized automatically to the video height. Default is off.
+
+```bash
+python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local --captions
+```
+
+Combine with other options:
+
+```bash
+python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local --crop-mode shot --captions
+```
+
 ### With options
 
 ```bash
@@ -191,6 +205,7 @@ xargs -a urls.txt -I{} python main.py "{}"
 | `--format` | `720` | Source download resolution: `360` / `480` / `720` / `1080` |
 | `--language` | auto | Force Whisper language code (e.g. `en`) |
 | `--crop-mode` | `face` | Local mode only: `face` (face-tracking) or `shot` (shot-aware action centering) |
+| `--captions` | off | Local mode only: burn transcript captions into the output clips |
 | `--output-json` | — | Dump the full result (transcript + all candidates) to a file |
 
 ### API mode vs Local mode
@@ -276,6 +291,20 @@ Set `LLM_PROVIDER=ollama` to run highlight ranking through any Ollama-compatible
    ```bash
    python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local
    ```
+
+**Context window (`OLLAMA_NUM_CTX`)**
+
+By default the context window is set to **32768 tokens** (the maximum for Qwen 2.5 and most modern models). If you run into VRAM limits, set a lower value in `.env`:
+
+```bash
+OLLAMA_NUM_CTX=16384   # or 8192, 4096, etc.
+```
+
+The value is passed as `num_ctx` in the Ollama `/api/chat` options. You can also set it per-run:
+
+```bash
+OLLAMA_NUM_CTX=8192 python main.py "..." --mode local
+```
 
 **Remote Ollama example** (e.g. on a cloud GPU):
 ```bash

--- a/main.py
+++ b/main.py
@@ -38,6 +38,12 @@ def main() -> int:
         default="face",
         help="Local mode only: 'face' (default, face-tracking) or 'shot' (shot-aware action centering)",
     )
+    parser.add_argument(
+        "--captions",
+        action="store_true",
+        default=False,
+        help="Burn transcript captions into the output clips (local mode only, default: off)",
+    )
     args = parser.parse_args()
 
     try:
@@ -49,6 +55,7 @@ def main() -> int:
             language=args.language,
             mode=args.mode,
             crop_mode=args.crop_mode,
+            captions=args.captions,
         )
     except Exception as e:
         print(f"\nFAILED: {e}", file=sys.stderr)

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ def main() -> int:
         help="api (default, MuAPI) or local (remote URL, file://, or local path + faster-whisper + LLM provider + ffmpeg).",
     )
     parser.add_argument("--num-clips", type=int, default=3, help="How many shorts to render (default: 3)")
+    parser.add_argument("--clip-length", type=int, default=None, help="Target clip length in seconds (±5s tolerance, default: 45)")
     parser.add_argument("--aspect-ratio", default="9:16", help="Output aspect ratio (default: 9:16)")
     parser.add_argument("--format", default="720", help="Source download resolution: 360 / 480 / 720 / 1080 (default: 720)")
     parser.add_argument("--language", default=None, help="Force Whisper language code, e.g. 'en' (default: auto-detect)")
@@ -50,6 +51,7 @@ def main() -> int:
         result = generate_shorts(
             youtube_url=args.url,
             num_clips=args.num_clips,
+            clip_length=args.clip_length,
             aspect_ratio=args.aspect_ratio,
             download_format=args.format,
             language=args.language,

--- a/main.py
+++ b/main.py
@@ -45,6 +45,12 @@ def main() -> int:
         default=False,
         help="Burn transcript captions into the output clips (local mode only, default: off)",
     )
+    parser.add_argument(
+        "--generate-metadata",
+        action="store_true",
+        default=False,
+        help="Generate YouTube + TikTok titles, descriptions, and hashtags for each short (default: off)",
+    )
     args = parser.parse_args()
 
     try:
@@ -58,6 +64,7 @@ def main() -> int:
             mode=args.mode,
             crop_mode=args.crop_mode,
             captions=args.captions,
+            generate_metadata=args.generate_metadata,
         )
     except Exception as e:
         print(f"\nFAILED: {e}", file=sys.stderr)
@@ -67,11 +74,17 @@ def main() -> int:
     print(f"Mode:          {result.get('mode', args.mode)}")
     print(f"Source video:  {result['source_video_url']}")
     print(f"Highlights:    {len(result['highlights'])} candidates → kept top {len(result['shorts'])}")
+    if result.get("metadata_file"):
+        print(f"Metadata file: {result['metadata_file']}")
     print("=" * 72)
     for i, s in enumerate(result["shorts"], 1):
         print(f"\n#{i}  score={s.get('score')}  {s.get('start_time'):.1f}s → {s.get('end_time'):.1f}s")
         print(f"     title:  {s.get('title')}")
         print(f"     hook:   {s.get('hook_sentence')}")
+        if s.get("youtube_title"):
+            print(f"     YT:     {s['youtube_title']}")
+        if s.get("tiktok_caption"):
+            print(f"     TT:     {s['tiktok_caption']}")
         if s.get("clip_url"):
             print(f"     clip:   {s['clip_url']}")
         else:

--- a/main.py
+++ b/main.py
@@ -32,6 +32,12 @@ def main() -> int:
     parser.add_argument("--format", default="720", help="Source download resolution: 360 / 480 / 720 / 1080 (default: 720)")
     parser.add_argument("--language", default=None, help="Force Whisper language code, e.g. 'en' (default: auto-detect)")
     parser.add_argument("--output-json", default=None, help="Write the full result JSON to this path")
+    parser.add_argument(
+        "--crop-mode",
+        choices=["face", "shot"],
+        default="face",
+        help="Local mode only: 'face' (default, face-tracking) or 'shot' (shot-aware action centering)",
+    )
     args = parser.parse_args()
 
     try:
@@ -42,6 +48,7 @@ def main() -> int:
             download_format=args.format,
             language=args.language,
             mode=args.mode,
+            crop_mode=args.crop_mode,
         )
     except Exception as e:
         print(f"\nFAILED: {e}", file=sys.stderr)

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -22,6 +22,10 @@ OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434").rstrip(
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3.2")
 OLLAMA_TIMEOUT = float(os.getenv("OLLAMA_TIMEOUT", "300"))
 OLLAMA_NUM_CTX = int(os.getenv("OLLAMA_NUM_CTX", "32768"))
+
+# Target clip length in seconds (±5s tolerance). Leave unset to use the original 45-90s sweet spot.
+CLIP_LENGTH = os.getenv("CLIP_LENGTH")
+CLIP_LENGTH = int(CLIP_LENGTH) if CLIP_LENGTH else None
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda
 LOCAL_OUTPUT_DIR = os.getenv("LOCAL_OUTPUT_DIR", "output")

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -16,6 +16,11 @@ OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "").strip()
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
+
+# Ollama settings — works with local or remote Ollama instances
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3.2")
+OLLAMA_TIMEOUT = float(os.getenv("OLLAMA_TIMEOUT", "300"))
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda
 LOCAL_OUTPUT_DIR = os.getenv("LOCAL_OUTPUT_DIR", "output")
@@ -65,3 +70,12 @@ def require_gemini_key() -> str:
             "Add it to your .env or export it, or switch LLM_PROVIDER back to openai."
         )
     return GEMINI_API_KEY
+
+
+def require_ollama_url() -> str:
+    if not OLLAMA_BASE_URL:
+        raise RuntimeError(
+            "OLLAMA_BASE_URL is not set. Local mode needs an Ollama endpoint when LLM_PROVIDER=ollama. "
+            "Add it to your .env or export it (e.g. http://localhost:11434)."
+        )
+    return OLLAMA_BASE_URL

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -21,6 +21,7 @@ LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3.2")
 OLLAMA_TIMEOUT = float(os.getenv("OLLAMA_TIMEOUT", "300"))
+OLLAMA_NUM_CTX = int(os.getenv("OLLAMA_NUM_CTX", "32768"))
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda
 LOCAL_OUTPUT_DIR = os.getenv("LOCAL_OUTPUT_DIR", "output")

--- a/shorts_generator/highlights.py
+++ b/shorts_generator/highlights.py
@@ -15,6 +15,7 @@ import re
 from typing import Callable, Dict, List, Optional
 
 from . import muapi
+from .config import CLIP_LENGTH
 
 
 LLMFn = Callable[[str], str]
@@ -50,6 +51,27 @@ Your task: identify the most viral-worthy highlights from the transcript.
 Rules:
 - Every highlight must open with a strong HOOK — a line that grabs attention within the first 3 seconds
 - Duration sweet spot: 45-90 seconds. Go shorter (20-44s) only for a perfect standalone one-liner. Go longer (91-180s) only when a story arc needs full context to land
+- Never cut mid-sentence or mid-thought — each clip must feel complete and self-contained
+- Clips must not overlap significantly with each other
+- Score 0-100 on viral potential (not general quality)
+- {num_clips_instruction}
+- For each highlight, identify the single best "hook_sentence" — the opening line that would make someone stop scrolling
+- Explain in one sentence why this clip is viral ("virality_reason")
+
+Respond ONLY with valid JSON (no markdown, no explanation):
+{{"highlights":[{{"title":"string","start_time":float,"end_time":float,"score":int,"hook_sentence":"string","virality_reason":"string"}}]}}"""
+
+HIGHLIGHT_SYSTEM_PROMPT_FIXED_LENGTH = """You are an elite short-form video editor who has studied thousands of viral clips on TikTok, Instagram Reels, and YouTube Shorts. You know exactly what makes viewers stop scrolling, watch to the end, and share.
+
+{virality_criteria}
+
+Content type: {content_type} | Density: {density}
+
+Your task: identify the most viral-worthy highlights from the transcript.
+
+Rules:
+- Every highlight must open with a strong HOOK — a line that grabs attention within the first 3 seconds
+- CRITICAL: Each clip MUST be between {target_min} and {target_max} seconds long. This is the most important rule. Clips shorter than {target_min}s or longer than {target_max}s will be rejected.
 - Never cut mid-sentence or mid-thought — each clip must feel complete and self-contained
 - Clips must not overlap significantly with each other
 - Score 0-100 on viral potential (not general quality)
@@ -124,7 +146,7 @@ def _coerce_int(value: object, default: int = 0) -> int:
         return default
 
 
-def _sanitize_highlights(raw_highlights: object, duration: float) -> List[Dict]:
+def _sanitize_highlights(raw_highlights: object, duration: float, min_duration: float = 3.0, max_duration: float = float("inf")) -> List[Dict]:
     """Normalize model output into the expected shape; skip invalid entries."""
     if not isinstance(raw_highlights, list):
         return []
@@ -145,6 +167,11 @@ def _sanitize_highlights(raw_highlights: object, duration: float) -> List[Dict]:
             end = min(end, max_end)
             if end <= start:
                 continue
+
+        # Enforce duration bounds — reject anything too short or too long
+        clip_dur = end - start
+        if clip_dur < min_duration or clip_dur > max_duration:
+            continue
 
         cleaned.append(
             {
@@ -204,18 +231,36 @@ def call_highlight_api(
     num_clips: int,
     is_chunk: bool = False,
     llm_fn: LLMFn = call_muapi_llm,
+    clip_length: Optional[int] = None,
 ) -> Dict:
+    # Use fixed-length prompt only when user explicitly sets clip_length
+    use_fixed = clip_length is not None or CLIP_LENGTH is not None
+    target = clip_length if clip_length is not None else (CLIP_LENGTH if CLIP_LENGTH is not None else 45)
+    target_min = max(5, target - 5)
+    target_max = target + 5
+
     # Ask for ~2× the user's target so dedupe has headroom, but cap so the model
     # doesn't have to generate a huge JSON payload (which times out gpt-5-mini).
     target = max(num_clips * 2, 5)
-    natural_max = max(2 if is_chunk else 3, int(duration / 90))
+    natural_max = max(2 if is_chunk else 3, int(duration / target_max))
     min_clips = min(target, natural_max, 8)
-    system = HIGHLIGHT_SYSTEM_PROMPT.format(
-        virality_criteria=VIRALITY_CRITERIA,
-        content_type=content_info.get("content_type", "other"),
-        density=content_info.get("density", "medium"),
-        num_clips_instruction=f"Generate at least {min_clips} highlights",
-    )
+
+    if use_fixed:
+        system = HIGHLIGHT_SYSTEM_PROMPT_FIXED_LENGTH.format(
+            virality_criteria=VIRALITY_CRITERIA,
+            content_type=content_info.get("content_type", "other"),
+            density=content_info.get("density", "medium"),
+            num_clips_instruction=f"Generate at least {min_clips} highlights",
+            target_min=target_min,
+            target_max=target_max,
+        )
+    else:
+        system = HIGHLIGHT_SYSTEM_PROMPT.format(
+            virality_criteria=VIRALITY_CRITERIA,
+            content_type=content_info.get("content_type", "other"),
+            density=content_info.get("density", "medium"),
+            num_clips_instruction=f"Generate at least {min_clips} highlights",
+        )
     base_prompt = f"{system}\n\nTranscript:\n{transcript_text}"
     prompt = base_prompt
     last_error = "unknown"
@@ -224,7 +269,10 @@ def call_highlight_api(
         raw = llm_fn(prompt)
         try:
             parsed = _parse_json_loose(raw)
-            highlights = _sanitize_highlights(parsed.get("highlights"), duration=duration)
+            if use_fixed:
+                highlights = _sanitize_highlights(parsed.get("highlights"), duration=duration, min_duration=target_min, max_duration=target_max)
+            else:
+                highlights = _sanitize_highlights(parsed.get("highlights"), duration=duration)
             if highlights:
                 return {"highlights": highlights}
             last_error = "no valid highlights in response"
@@ -272,6 +320,7 @@ def dedupe_highlights(highlights: List[Dict]) -> List[Dict]:
 def get_highlights(
     transcript: Dict,
     num_clips: int = 3,
+    clip_length: Optional[int] = None,
     llm_fn: Optional[LLMFn] = None,
 ) -> Dict:
     """Main entry point — returns {highlights: [...]} sorted by score.
@@ -292,7 +341,7 @@ def get_highlights(
             offset = chunk.get("_offset", 0)
             text = build_transcript_text(chunk)
             print(f"[highlights] chunk {i + 1}/{len(chunks)} (offset {offset:.0f}s)", flush=True)
-            result = call_highlight_api(text, content_info, chunk["duration"], num_clips=num_clips, is_chunk=True, llm_fn=llm_fn)
+            result = call_highlight_api(text, content_info, chunk["duration"], num_clips=num_clips, is_chunk=True, llm_fn=llm_fn, clip_length=clip_length)
             for h in result.get("highlights", []):
                 h["start_time"] = float(h["start_time"]) + offset
                 h["end_time"] = float(h["end_time"]) + offset
@@ -300,7 +349,7 @@ def get_highlights(
         highlights = dedupe_highlights(all_highlights)
     else:
         text = build_transcript_text(transcript)
-        result = call_highlight_api(text, content_info, duration, num_clips=num_clips, llm_fn=llm_fn)
+        result = call_highlight_api(text, content_info, duration, num_clips=num_clips, llm_fn=llm_fn, clip_length=clip_length)
         highlights = dedupe_highlights(result.get("highlights", []))
 
     return {"highlights": highlights}

--- a/shorts_generator/local/clipper.py
+++ b/shorts_generator/local/clipper.py
@@ -17,6 +17,144 @@ from typing import Dict, List, Optional, Tuple
 from ..config import LOCAL_OUTPUT_DIR
 
 
+def _burn_captions(
+    video_path: str,
+    out_path: str,
+    segments: List[Dict],
+    highlight_start: float,
+    highlight_end: float,
+) -> str:
+    """Burn transcript captions into the video using ffmpeg drawtext.
+
+    - Max 14 characters per caption chunk.
+    - Show captions ONLY during their actual segment time window.
+    - Each short gets a random color/style.
+    Uses textfile to avoid escaping issues with special characters.
+    """
+    import random
+    import tempfile
+
+    # Filter segments to those overlapping the highlight window
+    relevant = [
+        s for s in segments
+        if float(s["end"]) > highlight_start and float(s["start"]) < highlight_end
+    ]
+    if not relevant:
+        subprocess.run(
+            ["ffmpeg", "-y", "-loglevel", "error", "-i", video_path, "-c", "copy", out_path],
+            check=True,
+        )
+        return out_path
+
+    # Random style for this short
+    colors = [
+        "white", "yellow", "#00FFFF", "#FF6B6B", "#FFE66D",
+        "#FF9F43", "#A8E6CF", "#FDFFAB", "#FFB7B2", "#E2F0CB",
+    ]
+    border_colors = ["black", "#2C3E50", "#000000", "#1A1A2E", "#16213E"]
+    box_colors = [
+        "#000000@0.5", "#1A1A2E@0.4", "#2C3E50@0.4",
+        "#000000@0.6", "#1A1A2E@0.3",
+    ]
+    fonts = [
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+        "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf",
+    ]
+    fontfile = next((f for f in fonts if os.path.exists(f)), fonts[0])
+    font_color = random.choice(colors)
+    border_color = random.choice(border_colors)
+    box_color = random.choice(box_colors)
+    y_pos = random.choice(["h*0.82", "h*0.85", "h*0.88"])
+
+    def _chunk_segments(segments: List[Dict], max_chars: int = 12, max_gap: float = 0.3) -> List[Dict]:
+        """Group adjacent word segments into chunks of max_chars, preferring 2 words.
+        
+        Only groups 2 words if:
+        1. Combined length <= max_chars
+        2. Gap between word1 end and word2 start <= max_gap seconds
+        """
+        chunks = []
+        i = 0
+        while i < len(segments):
+            # Try 2 words first
+            if i + 1 < len(segments):
+                two_words = f"{segments[i]['text']} {segments[i+1]['text']}"
+                gap = float(segments[i+1]["start"]) - float(segments[i]["end"])
+                if len(two_words) <= max_chars and gap <= max_gap:
+                    chunks.append({
+                        "text": two_words,
+                        "start": segments[i]["start"],
+                        "end": segments[i+1]["end"],
+                    })
+                    i += 2
+                    continue
+            # Fall back to 1 word
+            chunks.append({
+                "text": segments[i]["text"],
+                "start": segments[i]["start"],
+                "end": segments[i]["end"],
+            })
+            i += 1
+        return chunks
+
+    drawtexts = []
+    temp_files = []
+
+    # Group relevant segments into chunks
+    chunks = _chunk_segments(relevant)
+
+    for chunk in chunks:
+        # Use the ACTUAL segment times — captions appear only when audio happens
+        chunk_start = max(float(chunk["start"]), highlight_start) - highlight_start
+        chunk_end = min(float(chunk["end"]), highlight_end) - highlight_start
+        text = chunk["text"]
+        if not text:
+            continue
+
+        if chunk_end <= chunk_start:
+            continue
+
+        fd, txt_path = tempfile.mkstemp(suffix=".txt", prefix="caption_")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        temp_files.append(txt_path)
+
+        dt = (
+            f"drawtext=fontfile={fontfile}:"
+            f"textfile='{txt_path}':"
+            f"fontcolor={font_color}:fontsize=h/14:"
+            f"borderw=4:bordercolor={border_color}:"
+            f"box=1:boxcolor={box_color}:boxborderw=8:"
+            f"x=(w-text_w)/2:y={y_pos}:"
+            f"enable='between(t\,{chunk_start:.3f}\,{chunk_end:.3f})'"
+        )
+        drawtexts.append(dt)
+
+    vf = ",".join(drawtexts)
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-i", video_path,
+        "-vf", vf,
+        "-c:a", "copy",
+        "-c:v", "libx264", "-preset", "fast", "-crf", "20",
+        out_path,
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    finally:
+        for p in temp_files:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+    return out_path
+
+
+
+
+
 def _ratio(aspect_ratio: str) -> float:
     """Parse '9:16' → 9/16, '1:1' → 1.0."""
     try:
@@ -330,22 +468,36 @@ def crop_clip_local(
     aspect_ratio: str,
     out_path: str,
     crop_mode: str = "face",
+    captions: bool = False,
+    transcript_segments: Optional[List[Dict]] = None,
 ) -> str:
     """Cut + reframe one highlight, returning the local mp4 path.
 
     Args:
         crop_mode: "face" (default) or "shot" (shot-aware action centering).
+        captions: Whether to burn transcript captions into the output.
+        transcript_segments: Required when captions=True — list of {start, end, text}.
     """
     cut_path = out_path + ".cut.mp4"
+    reframe_path = out_path + ".reframe.mp4"
     try:
         _cut_subclip(source_path, start_time, end_time, cut_path)
         if crop_mode == "shot":
-            _reframe_shot_aware(cut_path, out_path, aspect_ratio)
+            _reframe_shot_aware(cut_path, reframe_path, aspect_ratio)
         else:
-            _reframe_vertical(cut_path, out_path, aspect_ratio)
+            _reframe_vertical(cut_path, reframe_path, aspect_ratio)
+
+        if captions and transcript_segments:
+            _burn_captions(reframe_path, out_path, transcript_segments, start_time, end_time)
+        else:
+            os.rename(reframe_path, out_path)
     finally:
         if os.path.exists(cut_path):
             os.remove(cut_path)
+        if os.path.exists(reframe_path) and os.path.exists(out_path) and os.path.samefile(reframe_path, out_path):
+            pass  # already renamed
+        elif os.path.exists(reframe_path):
+            os.remove(reframe_path)
     return out_path
 
 
@@ -355,13 +507,16 @@ def crop_highlights_local(
     aspect_ratio: str = "9:16",
     out_dir: Optional[str] = None,
     crop_mode: str = "face",
+    captions: bool = False,
+    transcript_segments: Optional[List[Dict]] = None,
 ) -> List[Dict]:
     out_dir = out_dir or LOCAL_OUTPUT_DIR
     os.makedirs(out_dir, exist_ok=True)
     results: List[Dict] = []
     for i, h in enumerate(highlights, 1):
         out_path = os.path.join(out_dir, f"short_{i:02d}.mp4")
-        print(f"[clip/local] {i}/{len(highlights)}: {h.get('title', '(untitled)')} [{crop_mode} mode]", flush=True)
+        cap_label = "+captions" if captions else ""
+        print(f"[clip/local] {i}/{len(highlights)}: {h.get('title', '(untitled)')} [{crop_mode} mode{cap_label}]", flush=True)
         try:
             crop_clip_local(
                 source_path,
@@ -370,6 +525,8 @@ def crop_highlights_local(
                 aspect_ratio,
                 out_path,
                 crop_mode=crop_mode,
+                captions=captions,
+                transcript_segments=transcript_segments,
             )
             results.append({**h, "clip_url": out_path})
         except Exception as e:

--- a/shorts_generator/local/clipper.py
+++ b/shorts_generator/local/clipper.py
@@ -1,10 +1,14 @@
-"""Local clipping: ffmpeg subclip + OpenCV face-aware vertical crop.
+"""Local clipping: ffmpeg subclip + OpenCV face-aware or shot-aware vertical crop.
 
 Two stages per highlight:
   1. Cut the source video to [start, end] with ffmpeg (re-encoded, audio kept).
-  2. Reframe the cut to the target aspect ratio. For 9:16 we slide a vertical
-     window horizontally across the frame to keep faces centred (Haar
-     cascade — same approach as the original repo, no external models).
+  2. Reframe the cut to the target aspect ratio.
+
+Crop modes:
+  * face (default) — Haar cascade face tracking with smoothing.
+  * shot           — Detect shot boundaries, then for each shot find the
+                     maximum action area and lock the crop there until the
+                     next shot change. Prevents mid-shot drift.
 """
 import os
 import subprocess
@@ -122,18 +126,223 @@ def _reframe_vertical(in_path: str, out_path: str, aspect_ratio: str) -> str:
     return out_path
 
 
+def _detect_shot_boundaries(
+    cap,
+    threshold: float = 30.0,
+    min_shot_frames: int = 15,
+) -> List[int]:
+    """Return frame indices where shot changes occur.
+
+    Uses frame-difference histogram comparison. A shot boundary is declared
+    when the mean absolute difference between consecutive grayscale frames
+    exceeds `threshold` and at least `min_shot_frames` have passed since the
+    last boundary.
+    """
+    import cv2
+
+    prev_gray = None
+    boundaries: List[int] = []
+    frame_idx = 0
+    last_boundary = -min_shot_frames
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        if prev_gray is not None:
+            diff = cv2.absdiff(gray, prev_gray)
+            mean_diff = float(diff.mean())
+            if mean_diff > threshold and (frame_idx - last_boundary) >= min_shot_frames:
+                boundaries.append(frame_idx)
+                last_boundary = frame_idx
+        prev_gray = gray
+        frame_idx += 1
+
+    cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+    return boundaries
+
+
+def _find_action_center(
+    cap,
+    start_frame: int,
+    end_frame: int,
+    crop_w: int,
+    crop_h: int,
+) -> Tuple[int, int]:
+    """For a shot range, compute the most active region and return its center.
+
+    Motion is estimated via optical-flow magnitude averaged over the shot.
+    The crop window is positioned so its center sits on the highest-motion area.
+    Falls back to frame center if motion is negligible.
+    """
+    import cv2
+    import numpy as np
+
+    cap.set(cv2.CAP_PROP_POS_FRAMES, start_frame)
+    prev_gray = None
+    motion_map = None
+    frame_count = 0
+
+    for _ in range(start_frame, end_frame):
+        ret, frame = cap.read()
+        if not ret:
+            break
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        if prev_gray is not None:
+            flow = cv2.calcOpticalFlowFarneback(
+                prev_gray, gray, None,
+                pyr_scale=0.5, levels=3, winsize=15,
+                iterations=3, poly_n=5, poly_sigma=1.2, flags=0,
+            )
+            mag = np.sqrt(flow[..., 0] ** 2 + flow[..., 1] ** 2)
+            if motion_map is None:
+                motion_map = mag
+            else:
+                motion_map += mag
+            frame_count += 1
+        prev_gray = gray
+
+    if motion_map is None or frame_count == 0:
+        src_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        src_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        return src_w // 2, src_h // 2
+
+    # Average motion and find the best crop position
+    avg_motion = motion_map / frame_count
+    # Downsample motion map to a grid for speed
+    h, w = avg_motion.shape
+    grid_h = max(1, h // crop_h)
+    grid_w = max(1, w // crop_w)
+    pooled = cv2.resize(avg_motion, (grid_w, grid_h), interpolation=cv2.INTER_AREA)
+
+    # Find the grid cell with max motion
+    max_y, max_x = np.unravel_index(np.argmax(pooled), pooled.shape)
+    cx = int((max_x + 0.5) * crop_w)
+    cy = int((max_y + 0.5) * crop_h)
+
+    src_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    src_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    cx = max(crop_w // 2, min(src_w - crop_w // 2, cx))
+    cy = max(crop_h // 2, min(src_h - crop_h // 2, cy))
+    return cx, cy
+
+
+def _reframe_shot_aware(in_path: str, out_path: str, aspect_ratio: str) -> str:
+    """Crop the cut clip to the target aspect ratio, locking per-shot centers.
+
+    Steps:
+      1. Detect shot boundaries via frame differencing.
+      2. For each shot, compute the maximum action area via optical flow.
+      3. Lock the crop center for that shot; no smoothing between shots.
+    """
+    try:
+        import cv2  # type: ignore
+        import numpy as np
+    except ImportError as e:
+        raise RuntimeError(
+            "opencv-python is required for --mode local. Install it with:\n"
+            "    pip install -r requirements-local.txt"
+        ) from e
+
+    target_ratio = _ratio(aspect_ratio)
+    cap = cv2.VideoCapture(in_path)
+    if not cap.isOpened():
+        raise RuntimeError(f"could not open {in_path}")
+
+    src_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    src_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+    if target_ratio < src_w / src_h:
+        crop_h = src_h
+        crop_w = int(crop_h * target_ratio)
+    else:
+        crop_w = src_w
+        crop_h = int(crop_w / target_ratio)
+    crop_w = max(2, crop_w - (crop_w % 2))
+    crop_h = max(2, crop_h - (crop_h % 2))
+
+    # Detect shot boundaries
+    boundaries = _detect_shot_boundaries(cap)
+    shot_ranges = []
+    prev = 0
+    for b in boundaries:
+        shot_ranges.append((prev, b))
+        prev = b
+    shot_ranges.append((prev, total_frames))
+
+    # Pre-compute action center for each shot
+    shot_centers: List[Tuple[int, int]] = []
+    for start_f, end_f in shot_ranges:
+        cx, cy = _find_action_center(cap, start_f, end_f, crop_w, crop_h)
+        shot_centers.append((cx, cy))
+
+    # Render with locked per-shot centers
+    silent_path = out_path + ".silent.mp4"
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(silent_path, fourcc, fps, (crop_w, crop_h))
+
+    current_shot = 0
+    frame_idx = 0
+    cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        # Advance shot if we've crossed a boundary
+        while current_shot < len(shot_ranges) - 1 and frame_idx >= shot_ranges[current_shot][1]:
+            current_shot += 1
+
+        cx, cy = shot_centers[current_shot]
+        x0 = max(0, min(src_w - crop_w, cx - crop_w // 2))
+        y0 = max(0, min(src_h - crop_h, cy - crop_h // 2))
+        cropped = frame[y0:y0 + crop_h, x0:x0 + crop_w]
+        writer.write(cropped)
+        frame_idx += 1
+
+    cap.release()
+    writer.release()
+
+    # Mux audio back
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-i", silent_path,
+        "-i", in_path,
+        "-c:v", "copy",
+        "-c:a", "aac", "-b:a", "128k",
+        "-map", "0:v:0", "-map", "1:a:0?",
+        "-shortest",
+        out_path,
+    ]
+    subprocess.run(cmd, check=True)
+    os.remove(silent_path)
+    return out_path
+
+
 def crop_clip_local(
     source_path: str,
     start_time: float,
     end_time: float,
     aspect_ratio: str,
     out_path: str,
+    crop_mode: str = "face",
 ) -> str:
-    """Cut + reframe one highlight, returning the local mp4 path."""
+    """Cut + reframe one highlight, returning the local mp4 path.
+
+    Args:
+        crop_mode: "face" (default) or "shot" (shot-aware action centering).
+    """
     cut_path = out_path + ".cut.mp4"
     try:
         _cut_subclip(source_path, start_time, end_time, cut_path)
-        _reframe_vertical(cut_path, out_path, aspect_ratio)
+        if crop_mode == "shot":
+            _reframe_shot_aware(cut_path, out_path, aspect_ratio)
+        else:
+            _reframe_vertical(cut_path, out_path, aspect_ratio)
     finally:
         if os.path.exists(cut_path):
             os.remove(cut_path)
@@ -145,13 +354,14 @@ def crop_highlights_local(
     highlights: List[Dict],
     aspect_ratio: str = "9:16",
     out_dir: Optional[str] = None,
+    crop_mode: str = "face",
 ) -> List[Dict]:
     out_dir = out_dir or LOCAL_OUTPUT_DIR
     os.makedirs(out_dir, exist_ok=True)
     results: List[Dict] = []
     for i, h in enumerate(highlights, 1):
         out_path = os.path.join(out_dir, f"short_{i:02d}.mp4")
-        print(f"[clip/local] {i}/{len(highlights)}: {h.get('title', '(untitled)')}", flush=True)
+        print(f"[clip/local] {i}/{len(highlights)}: {h.get('title', '(untitled)')} [{crop_mode} mode]", flush=True)
         try:
             crop_clip_local(
                 source_path,
@@ -159,6 +369,7 @@ def crop_highlights_local(
                 float(h["end_time"]),
                 aspect_ratio,
                 out_path,
+                crop_mode=crop_mode,
             )
             results.append({**h, "clip_url": out_path})
         except Exception as e:

--- a/shorts_generator/local/llm.py
+++ b/shorts_generator/local/llm.py
@@ -1,10 +1,14 @@
-"""Local LLM backend — OpenAI or Gemini, selected by LLM_PROVIDER."""
+"""Local LLM backend — OpenAI, Gemini, or Ollama, selected by LLM_PROVIDER."""
 from ..config import (
     GEMINI_MODEL,
     LLM_PROVIDER,
+    OLLAMA_BASE_URL,
+    OLLAMA_MODEL,
+    OLLAMA_TIMEOUT,
     OPENAI_MODEL,
     require_gemini_key,
     require_openai_key,
+    require_ollama_url,
 )
 
 
@@ -50,6 +54,65 @@ def call_gemini_llm(prompt: str) -> str:
     return response.text or ""
 
 
+def call_ollama_llm(prompt: str) -> str:
+    """Ollama backend used by --mode local when LLM_PROVIDER=ollama.
+
+    Uses the /api/chat endpoint with proper system/user message separation
+    so the model understands instructions vs data. Works with any Ollama-
+    compatible endpoint (local laptop, LAN server, or cloud instances).
+    """
+    import json as _json
+    import urllib.request
+    import urllib.error
+
+    url = f"{require_ollama_url()}/api/chat"
+
+    # Split the prompt into system instructions and user content.
+    # The HIGHLIGHT_SYSTEM_PROMPT is everything before "Transcript:" or
+    # before the last "\n\nTranscript:\n" separator. If we can't split,
+    # fall back to sending it all as a user message.
+    system_part = ""
+    user_part = prompt
+    marker = "\n\nTranscript:\n"
+    idx = prompt.find(marker)
+    if idx != -1:
+        system_part = prompt[:idx]
+        user_part = prompt[idx + len(marker):]
+
+    messages = []
+    if system_part:
+        messages.append({"role": "system", "content": system_part})
+    messages.append({"role": "user", "content": user_part})
+
+    payload = _json.dumps({
+        "model": OLLAMA_MODEL,
+        "messages": messages,
+        "stream": False,
+        "options": {
+            "temperature": 0.7,
+        },
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=OLLAMA_TIMEOUT) as resp:
+            data = _json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Ollama HTTP {e.code}: {body}") from e
+    except Exception as e:
+        raise RuntimeError(f"Ollama request failed: {e}") from e
+
+    message = data.get("message", {})
+    return message.get("content", "")
+
+
 def call_local_llm(prompt: str) -> str:
     """Dispatch to the configured local LLM provider."""
     provider = (LLM_PROVIDER or "openai").strip().lower()
@@ -57,6 +120,8 @@ def call_local_llm(prompt: str) -> str:
         return call_openai_llm(prompt)
     if provider == "gemini":
         return call_gemini_llm(prompt)
+    if provider == "ollama":
+        return call_ollama_llm(prompt)
     raise RuntimeError(
-        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai' or 'gemini'."
+        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai', 'gemini', or 'ollama'."
     )

--- a/shorts_generator/local/llm.py
+++ b/shorts_generator/local/llm.py
@@ -4,6 +4,7 @@ from ..config import (
     LLM_PROVIDER,
     OLLAMA_BASE_URL,
     OLLAMA_MODEL,
+    OLLAMA_NUM_CTX,
     OLLAMA_TIMEOUT,
     OPENAI_MODEL,
     require_gemini_key,
@@ -90,6 +91,7 @@ def call_ollama_llm(prompt: str) -> str:
         "stream": False,
         "options": {
             "temperature": 0.7,
+            "num_ctx": OLLAMA_NUM_CTX,
         },
     }).encode("utf-8")
 

--- a/shorts_generator/local/transcriber.py
+++ b/shorts_generator/local/transcriber.py
@@ -137,6 +137,7 @@ def transcribe_local(media_path: str, language: Optional[str] = None) -> Dict:
         "language": language,
         "beam_size": 5,
         "condition_on_previous_text": False,
+        "word_timestamps": True,
     }
     if LOCAL_WHISPER_VAD_FILTER:
         transcribe_kwargs["vad_filter"] = True
@@ -148,11 +149,20 @@ def transcribe_local(media_path: str, language: Optional[str] = None) -> Dict:
 
     segments = []
     for s in segments_iter:
-        segments.append({
-            "start": float(s.start),
-            "end": float(s.end),
-            "text": (s.text or "").strip(),
-        })
+        # If word-level timestamps are available, use them for precise timing
+        if hasattr(s, 'words') and s.words:
+            for w in s.words:
+                segments.append({
+                    "start": float(w.start),
+                    "end": float(w.end),
+                    "text": (w.word or "").strip(),
+                })
+        else:
+            segments.append({
+                "start": float(s.start),
+                "end": float(s.end),
+                "text": (s.text or "").strip(),
+            })
 
     duration = float(getattr(info, "duration", 0.0)) or (segments[-1]["end"] if segments else 0.0)
     print(f"[transcribe/local] {len(segments)} segments, {duration:.0f}s of audio", flush=True)

--- a/shorts_generator/metadata.py
+++ b/shorts_generator/metadata.py
@@ -1,0 +1,190 @@
+"""Generate platform-specific titles and descriptions for each short.
+
+Uses the same LLM backend as highlight ranking (OpenAI / Gemini / Ollama in local
+mode, MuAPI in API mode) to produce:
+  - YouTube title + description
+  - TikTok caption + hashtags
+
+The prompt includes the short's transcript text, hook sentence, and virality
+reason so the metadata is grounded in the actual content.
+"""
+import json
+import re
+from typing import Callable, Dict, List, Optional
+
+from .config import CLIP_LENGTH
+from .highlights import LLMFn, call_muapi_llm
+
+
+METADATA_SYSTEM_PROMPT = """You are a viral social-media copywriter who writes scroll-stopping titles and descriptions for short-form video clips.
+
+Given a short video clip's transcript, hook, and virality reason, write:
+1. A YouTube Shorts title (max 60 chars, punchy, includes keywords)
+2. A YouTube Shorts description (2-3 sentences, engaging, includes relevant hashtags)
+3. A TikTok caption (max 100 chars, trendy, emoji-friendly)
+4. TikTok hashtags (5-8 hashtags, mix of broad and niche)
+
+Rules:
+- Titles must be attention-grabbing and accurate to the content
+- Descriptions should tease the content without giving everything away
+- TikTok captions should feel native to the platform (casual, emoji, trends)
+- Hashtags must be relevant to the actual content, not generic spam
+- NEVER use clickbait that misrepresents the content
+
+Respond ONLY with valid JSON (no markdown, no explanation):
+{"youtube_title":"string","youtube_description":"string","tiktok_caption":"string","tiktok_hashtags":"#tag1 #tag2 ..."}"""
+
+
+def _parse_json_loose(raw: str) -> Dict:
+    """Strip markdown fences and parse JSON."""
+    text = raw.strip()
+    text = re.sub(r"^```(?:json)?\s*", "", text)
+    text = re.sub(r"\s*```$", "", text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start != -1 and end != -1:
+            return json.loads(text[start:end + 1])
+        raise
+
+
+def generate_short_metadata(
+    highlight: Dict,
+    transcript_segments: List[Dict],
+    llm_fn: Optional[LLMFn] = None,
+) -> Dict:
+    """Generate YouTube + TikTok metadata for a single short.
+
+    Args:
+        highlight: dict with title, start_time, end_time, hook_sentence, virality_reason
+        transcript_segments: list of {start, end, text} for the full video
+        llm_fn: LLM callable (defaults to MuAPI gpt-5-mini)
+
+    Returns:
+        {
+            "youtube_title": str,
+            "youtube_description": str,
+            "tiktok_caption": str,
+            "tiktok_hashtags": str,
+        }
+    """
+    llm_fn = llm_fn or call_muapi_llm
+
+    start = float(highlight.get("start_time", 0))
+    end = float(highlight.get("end_time", 0))
+
+    # Extract transcript text within the clip's time window
+    clip_texts = [
+        s["text"] for s in transcript_segments
+        if float(s.get("start", 0)) >= start and float(s.get("end", 0)) <= end
+    ]
+    clip_transcript = " ".join(clip_texts).strip()
+    if not clip_transcript:
+        # Fallback: grab segments that overlap the window
+        clip_texts = [
+            s["text"] for s in transcript_segments
+            if float(s.get("start", 0)) < end and float(s.get("end", 0)) > start
+        ]
+        clip_transcript = " ".join(clip_texts).strip()
+
+    hook = highlight.get("hook_sentence", "")
+    reason = highlight.get("virality_reason", "")
+    title = highlight.get("title", "")
+
+    prompt = (
+        f"{METADATA_SYSTEM_PROMPT}\n\n"
+        f"Clip title: {title}\n"
+        f"Hook: {hook}\n"
+        f"Why it's viral: {reason}\n"
+        f"Transcript: {clip_transcript}\n\n"
+        f"Generate metadata:"
+    )
+
+    raw = llm_fn(prompt)
+    try:
+        parsed = _parse_json_loose(raw)
+        return {
+            "youtube_title": str(parsed.get("youtube_title", "")).strip(),
+            "youtube_description": str(parsed.get("youtube_description", "")).strip(),
+            "tiktok_caption": str(parsed.get("tiktok_caption", "")).strip(),
+            "tiktok_hashtags": str(parsed.get("tiktok_hashtags", "")).strip(),
+        }
+    except Exception as e:
+        print(f"[metadata] failed to parse LLM response: {e}", flush=True)
+        return {
+            "youtube_title": title,
+            "youtube_description": f"{hook}\n\n{reason}",
+            "tiktok_caption": hook,
+            "tiktok_hashtags": "#shorts #viral #trending",
+        }
+
+
+def generate_all_metadata(
+    highlights: List[Dict],
+    transcript_segments: List[Dict],
+    llm_fn: Optional[LLMFn] = None,
+) -> List[Dict]:
+    """Generate metadata for every highlight and attach it back.
+
+    Returns a new list of highlight dicts with added keys:
+        youtube_title, youtube_description, tiktok_caption, tiktok_hashtags
+    """
+    results = []
+    for i, h in enumerate(highlights, 1):
+        print(f"[metadata] {i}/{len(highlights)}: {h.get('title', '(untitled)')}", flush=True)
+        meta = generate_short_metadata(h, transcript_segments, llm_fn=llm_fn)
+        results.append({**h, **meta})
+    return results
+
+
+def write_metadata_file(
+    shorts: List[Dict],
+    out_path: str,
+    source_url: str = "",
+) -> str:
+    """Write a human-readable metadata file alongside the shorts.
+
+    Args:
+        shorts: list of short dicts with metadata keys
+        out_path: path to write the file (e.g. output/shorts_metadata.txt)
+        source_url: original source video URL for reference
+
+    Returns:
+        The written file path.
+    """
+    lines = []
+    lines.append("=" * 72)
+    lines.append("SHORT-FORM VIDEO METADATA")
+    lines.append("=" * 72)
+    if source_url:
+        lines.append(f"Source: {source_url}")
+    lines.append("")
+
+    for i, s in enumerate(shorts, 1):
+        lines.append("-" * 72)
+        lines.append(f"SHORT #{i}")
+        lines.append("-" * 72)
+        lines.append(f"File: {s.get('clip_url', 'N/A')}")
+        lines.append(f"Time: {s.get('start_time', 0):.1f}s → {s.get('end_time', 0):.1f}s")
+        lines.append(f"Score: {s.get('score', 'N/A')}")
+        lines.append("")
+        lines.append("YOUTUBE")
+        lines.append(f"  Title:       {s.get('youtube_title', 'N/A')}")
+        lines.append(f"  Description: {s.get('youtube_description', 'N/A')}")
+        lines.append("")
+        lines.append("TIKTOK")
+        lines.append(f"  Caption:  {s.get('tiktok_caption', 'N/A')}")
+        lines.append(f"  Hashtags: {s.get('tiktok_hashtags', 'N/A')}")
+        lines.append("")
+
+    lines.append("=" * 72)
+    lines.append("END")
+    lines.append("=" * 72)
+
+    content = "\n".join(lines)
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    print(f"[metadata] wrote metadata file: {out_path}", flush=True)
+    return out_path

--- a/shorts_generator/pipeline.py
+++ b/shorts_generator/pipeline.py
@@ -20,6 +20,7 @@ def _run_local(
     aspect_ratio: str,
     download_format: str,
     language: Optional[str],
+    crop_mode: str = "face",
 ) -> Dict:
     from .local.clipper import crop_highlights_local
     from .local.downloader import download_youtube_local
@@ -42,7 +43,7 @@ def _run_local(
     top = sorted(all_highlights, key=lambda h: int(h.get("score", 0)), reverse=True)[:num_clips]
     print(f"[pipeline/local] cropping {len(top)} of {len(all_highlights)} candidates", flush=True)
 
-    shorts = crop_highlights_local(source_path, top, aspect_ratio=aspect_ratio)
+    shorts = crop_highlights_local(source_path, top, aspect_ratio=aspect_ratio, crop_mode=crop_mode)
 
     return {
         "mode": "local",
@@ -94,6 +95,7 @@ def generate_shorts(
     download_format: str = "720",
     language: Optional[str] = None,
     mode: str = "api",
+    crop_mode: str = "face",
 ) -> Dict:
     """Run the full pipeline and return a structured result.
 
@@ -105,6 +107,9 @@ def generate_shorts(
         language: ISO-639-1 to force Whisper language detection.
         mode: "api" (default, MuAPI) or "local" (yt-dlp + faster-whisper +
             OpenAI or Gemini + ffmpeg).
+        crop_mode: "face" (default) or "shot". Only used in local mode.
+            "shot" detects shot boundaries and locks the crop center per shot
+            using maximum action area (optical flow). Prevents mid-shot drift.
 
     Returns:
         {
@@ -117,7 +122,7 @@ def generate_shorts(
     """
     mode = (mode or "api").lower()
     if mode == "local":
-        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language)
+        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language, crop_mode=crop_mode)
     if mode == "api":
         return _run_api(youtube_url, num_clips, aspect_ratio, download_format, language)
     raise ValueError(f"Unknown mode: {mode!r}. Use 'api' or 'local'.")

--- a/shorts_generator/pipeline.py
+++ b/shorts_generator/pipeline.py
@@ -22,6 +22,7 @@ def _run_local(
     language: Optional[str],
     crop_mode: str = "face",
     captions: bool = False,
+    clip_length: Optional[int] = None,
 ) -> Dict:
     from .local.clipper import crop_highlights_local
     from .local.downloader import download_youtube_local
@@ -36,7 +37,7 @@ def _run_local(
             "Whisper produced no segments. The video may have no detectable speech."
         )
 
-    highlights_result = get_highlights(transcript, num_clips=num_clips, llm_fn=call_local_llm)
+    highlights_result = get_highlights(transcript, num_clips=num_clips, clip_length=clip_length, llm_fn=call_local_llm)
     all_highlights: List[Dict] = highlights_result.get("highlights", [])
     if not all_highlights:
         raise RuntimeError("Highlight generator returned zero clips.")
@@ -64,6 +65,7 @@ def _run_api(
     aspect_ratio: str,
     download_format: str,
     language: Optional[str],
+    clip_length: Optional[int] = None,
 ) -> Dict:
     source_url = download_youtube(youtube_url, fmt=download_format)
 
@@ -73,7 +75,7 @@ def _run_api(
             "Whisper produced no segments. The video may have no detectable speech."
         )
 
-    highlights_result = get_highlights(transcript, num_clips=num_clips, llm_fn=call_muapi_llm)
+    highlights_result = get_highlights(transcript, num_clips=num_clips, clip_length=clip_length, llm_fn=call_muapi_llm)
     all_highlights: List[Dict] = highlights_result.get("highlights", [])
     if not all_highlights:
         raise RuntimeError("Highlight generator returned zero clips.")
@@ -95,6 +97,7 @@ def _run_api(
 def generate_shorts(
     youtube_url: str,
     num_clips: int = 3,
+    clip_length: Optional[int] = None,
     aspect_ratio: str = "9:16",
     download_format: str = "720",
     language: Optional[str] = None,
@@ -107,6 +110,7 @@ def generate_shorts(
     Args:
         youtube_url: source URL.
         num_clips: how many shorts to render.
+        clip_length: target clip length in seconds (±5s tolerance). Default 45.
         aspect_ratio: e.g. "9:16", "1:1".
         download_format: source resolution ("360" / "480" / "720" / "1080").
         language: ISO-639-1 to force Whisper language detection.
@@ -129,7 +133,7 @@ def generate_shorts(
     """
     mode = (mode or "api").lower()
     if mode == "local":
-        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language, crop_mode=crop_mode, captions=captions)
+        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language, crop_mode=crop_mode, captions=captions, clip_length=clip_length)
     if mode == "api":
-        return _run_api(youtube_url, num_clips, aspect_ratio, download_format, language)
+        return _run_api(youtube_url, num_clips, aspect_ratio, download_format, language, clip_length=clip_length)
     raise ValueError(f"Unknown mode: {mode!r}. Use 'api' or 'local'.")

--- a/shorts_generator/pipeline.py
+++ b/shorts_generator/pipeline.py
@@ -3,8 +3,8 @@
 Two modes:
   * mode="api"   (default) — MuAPI does download / transcribe / LLM / autocrop.
                               Fast, no local deps, pay-per-call.
-  * mode="local"            — yt-dlp + faster-whisper + OpenAI or Gemini + ffmpeg/opencv.
-                              Self-hosted, LLM_PROVIDER selects OpenAI or Gemini.
+  * mode="local"            — yt-dlp + faster-whisper + OpenAI / Gemini / Ollama + ffmpeg/opencv.
+                              Self-hosted, LLM_PROVIDER selects OpenAI, Gemini, or Ollama.
 """
 from typing import Dict, List, Optional
 

--- a/shorts_generator/pipeline.py
+++ b/shorts_generator/pipeline.py
@@ -6,11 +6,13 @@ Two modes:
   * mode="local"            — yt-dlp + faster-whisper + OpenAI / Gemini / Ollama + ffmpeg/opencv.
                               Self-hosted, LLM_PROVIDER selects OpenAI, Gemini, or Ollama.
 """
+import os
 from typing import Dict, List, Optional
 
 from .clipper import crop_highlights
 from .downloader import download_youtube
 from .highlights import call_muapi_llm, get_highlights
+from .metadata import generate_all_metadata, write_metadata_file
 from .transcriber import transcribe
 
 
@@ -23,6 +25,7 @@ def _run_local(
     crop_mode: str = "face",
     captions: bool = False,
     clip_length: Optional[int] = None,
+    generate_metadata: bool = False,
 ) -> Dict:
     from .local.clipper import crop_highlights_local
     from .local.downloader import download_youtube_local
@@ -50,12 +53,23 @@ def _run_local(
         captions=captions, transcript_segments=transcript.get("segments"),
     )
 
+    if generate_metadata:
+        shorts = generate_all_metadata(
+            shorts, transcript.get("segments", []), llm_fn=call_local_llm
+        )
+        meta_path = os.path.join(
+            os.path.dirname(source_path) if os.path.dirname(source_path) else ".",
+            "shorts_metadata.txt"
+        )
+        write_metadata_file(shorts, meta_path, source_url=youtube_url)
+
     return {
         "mode": "local",
         "source_video_url": source_path,
         "transcript": transcript,
         "highlights": all_highlights,
         "shorts": shorts,
+        "metadata_file": meta_path if generate_metadata else None,
     }
 
 
@@ -66,6 +80,7 @@ def _run_api(
     download_format: str,
     language: Optional[str],
     clip_length: Optional[int] = None,
+    generate_metadata: bool = False,
 ) -> Dict:
     source_url = download_youtube(youtube_url, fmt=download_format)
 
@@ -85,12 +100,23 @@ def _run_api(
 
     shorts = crop_highlights(source_url, top, aspect_ratio=aspect_ratio)
 
+    if generate_metadata:
+        shorts = generate_all_metadata(
+            shorts, transcript.get("segments", []), llm_fn=call_muapi_llm
+        )
+        meta_path = os.path.join(
+            os.path.dirname(source_url) if os.path.dirname(source_url) else ".",
+            "shorts_metadata.txt"
+        )
+        write_metadata_file(shorts, meta_path, source_url=youtube_url)
+
     return {
         "mode": "api",
         "source_video_url": source_url,
         "transcript": transcript,
         "highlights": all_highlights,
         "shorts": shorts,
+        "metadata_file": meta_path if generate_metadata else None,
     }
 
 
@@ -104,6 +130,7 @@ def generate_shorts(
     mode: str = "api",
     crop_mode: str = "face",
     captions: bool = False,
+    generate_metadata: bool = False,
 ) -> Dict:
     """Run the full pipeline and return a structured result.
 
@@ -121,6 +148,8 @@ def generate_shorts(
             using maximum action area (optical flow). Prevents mid-shot drift.
         captions: Burn transcript captions into the output clips. Default False.
             Only supported in local mode.
+        generate_metadata: Generate YouTube + TikTok titles, descriptions, and
+            hashtags for each short. Default False.
 
     Returns:
         {
@@ -133,7 +162,7 @@ def generate_shorts(
     """
     mode = (mode or "api").lower()
     if mode == "local":
-        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language, crop_mode=crop_mode, captions=captions, clip_length=clip_length)
+        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language, crop_mode=crop_mode, captions=captions, clip_length=clip_length, generate_metadata=generate_metadata)
     if mode == "api":
-        return _run_api(youtube_url, num_clips, aspect_ratio, download_format, language, clip_length=clip_length)
+        return _run_api(youtube_url, num_clips, aspect_ratio, download_format, language, clip_length=clip_length, generate_metadata=generate_metadata)
     raise ValueError(f"Unknown mode: {mode!r}. Use 'api' or 'local'.")

--- a/shorts_generator/pipeline.py
+++ b/shorts_generator/pipeline.py
@@ -21,6 +21,7 @@ def _run_local(
     download_format: str,
     language: Optional[str],
     crop_mode: str = "face",
+    captions: bool = False,
 ) -> Dict:
     from .local.clipper import crop_highlights_local
     from .local.downloader import download_youtube_local
@@ -43,7 +44,10 @@ def _run_local(
     top = sorted(all_highlights, key=lambda h: int(h.get("score", 0)), reverse=True)[:num_clips]
     print(f"[pipeline/local] cropping {len(top)} of {len(all_highlights)} candidates", flush=True)
 
-    shorts = crop_highlights_local(source_path, top, aspect_ratio=aspect_ratio, crop_mode=crop_mode)
+    shorts = crop_highlights_local(
+        source_path, top, aspect_ratio=aspect_ratio, crop_mode=crop_mode,
+        captions=captions, transcript_segments=transcript.get("segments"),
+    )
 
     return {
         "mode": "local",
@@ -96,6 +100,7 @@ def generate_shorts(
     language: Optional[str] = None,
     mode: str = "api",
     crop_mode: str = "face",
+    captions: bool = False,
 ) -> Dict:
     """Run the full pipeline and return a structured result.
 
@@ -110,6 +115,8 @@ def generate_shorts(
         crop_mode: "face" (default) or "shot". Only used in local mode.
             "shot" detects shot boundaries and locks the crop center per shot
             using maximum action area (optical flow). Prevents mid-shot drift.
+        captions: Burn transcript captions into the output clips. Default False.
+            Only supported in local mode.
 
     Returns:
         {
@@ -122,7 +129,7 @@ def generate_shorts(
     """
     mode = (mode or "api").lower()
     if mode == "local":
-        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language, crop_mode=crop_mode)
+        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language, crop_mode=crop_mode, captions=captions)
     if mode == "api":
         return _run_api(youtube_url, num_clips, aspect_ratio, download_format, language)
     raise ValueError(f"Unknown mode: {mode!r}. Use 'api' or 'local'.")


### PR DESCRIPTION
Extends local mode to support `LLM_PROVIDER=ollama` alongside OpenAI and Gemini. Adds Ollama config/env variables (`OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_TIMEOUT`), validation for the endpoint URL, and a new Ollama `/api/chat` client path in `shorts_generator/local/llm.py` with clearer error reporting. Documentation and examples were updated in `.env.example`, `README.md`, and pipeline/module descriptions to explain setup, usage, and model recommendations.