### PR TITLE
feat: add optional Sonilo background-music step (--music)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # API mode (default)
 MUAPI_API_KEY=your_muapi_key_here
 
+# Background music (--music) — original soundtrack matched to each short (Sonilo)
+SONILO_API_KEY=your_sonilo_key_here
+SONILO_MUSIC_VOLUME=0.3       # music level under the original audio (0.0-1.0)
+
 # Local mode (--mode local)
 LLM_PROVIDER=openai           # openai or gemini
 OPENAI_API_KEY=your_openai_key_here

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Built for creators, agencies, and developers who don't want to pay $20–$300/mo
 - **🧩 Long-Video Aware**: Videos over 30 minutes are auto-chunked with overlap so nothing gets missed
 - **♻️ Smart Dedupe**: Overlapping highlights are collapsed by score so you never get two near-duplicate clips
 - **🎯 Smart Vertical Crop**: API mode uses MuAPI's auto-crop; local mode runs OpenCV face tracking with motion smoothing
+- **🎵 Optional Background Music (Sonilo)**: Pass `--music` and each rendered short gets an original soundtrack matched to the video — generated from the clip's pacing, motion, and emotion, mixed under the original audio at low volume so the speech stays intact. Tracks are licensed and safe for commercial use (terms apply)
 - **📱 Any Aspect Ratio**: 9:16 for TikTok/Reels/Shorts, 1:1 for square, anything else by flag
 - **🧰 CLI + Python Library**: Use it from the shell or import `generate_shorts(...)` into your own pipeline
 - **📦 JSON Output**: `--output-json` dumps the full result (transcript + every candidate highlight + final clip URLs/paths) for downstream automation
@@ -90,6 +91,10 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
    ```bash
    # API mode (default)
    MUAPI_API_KEY=your_muapi_key_here
+
+   # Background music (--music) — optional
+   SONILO_API_KEY=your_sonilo_key_here
+   SONILO_MUSIC_VOLUME=0.3           # optional, music level under the original audio
 
    # Local mode (--mode local)
    LLM_PROVIDER=openai         # openai or gemini
@@ -177,6 +182,8 @@ xargs -a urls.txt -I{} python main.py "{}"
 | `--aspect-ratio` | `9:16` | Any ratio; `9:16` for TikTok/Reels, `1:1` for square |
 | `--format` | `720` | Source download resolution: `360` / `480` / `720` / `1080` |
 | `--language` | auto | Force Whisper language code (e.g. `en`) |
+| `--music` | off | Give each short an original soundtrack matched to the video via [Sonilo](https://sonilo.com), mixed under the original audio (needs `SONILO_API_KEY`) |
+| `--music-prompt` | — | Optional style hint for `--music`, e.g. `"lofi hip hop, mellow"` |
 | `--output-json` | — | Dump the full result (transcript + all candidates) to a file |
 
 ### API mode vs Local mode
@@ -189,6 +196,42 @@ xargs -a urls.txt -I{} python main.py "{}"
 | Vertical crop | MuAPI `/autocrop` | `ffmpeg` + OpenCV face tracking |
 | Output | hosted URLs | local mp4 paths |
 | Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY` or `GEMINI_API_KEY` (+ `ffmpeg` on PATH) |
+
+### Background music (Sonilo)
+
+By default, shorts ship with their original audio only. Pass `--music` and each
+rendered short is sent to [Sonilo](https://sonilo.com)'s `/v1/video-to-music`
+endpoint, which analyzes the clip's pacing, motion, and emotion and returns an
+original soundtrack matched to the video. The track is then mixed under the
+clip's existing audio with `ffmpeg` at low volume (default `0.3`, tune with
+`SONILO_MUSIC_VOLUME`), so the speech stays fully intelligible. Generated
+tracks are licensed and safe for commercial use (terms apply).
+
+```bash
+# .env
+SONILO_API_KEY=your_sonilo_key   # https://platform.sonilo.com/dashboard/api-keys
+```
+
+```bash
+python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --music
+python main.py "/Users/you/Videos/input.mp4" --mode local --music \
+    --music-prompt "lofi hip hop, mellow"
+```
+
+Details:
+
+- **Fully opt-in.** Without `--music`, nothing changes — no Sonilo calls, no
+  new dependencies (the client uses the `requests` package already required
+  for API mode).
+- **Works in both modes.** The mix runs locally with `ffmpeg` (already
+  required for `--mode local`). In API mode the finished clip is downloaded
+  first, so the short with music lands in `LOCAL_OUTPUT_DIR` as
+  `short_XX.mp4` (the original hosted URL is kept as `source_clip_url`).
+- **The track is saved too.** Each short gets a `short_XX.music.m4a` next to
+  it, so you can remix at a different volume without regenerating.
+- **Failures never break the run.** Any per-clip problem (API error, missing
+  `ffmpeg`, clip over the endpoint's 6-minute duration limit) is logged and
+  that short ships with its original audio.
 
 ## How It Works
 
@@ -274,6 +317,7 @@ AI-Youtube-Shorts-Generator/
     ├── transcriber.py            API mode: MuAPI /openai-whisper client
     ├── highlights.py             shared LLM virality ranking (pluggable backend)
     ├── clipper.py                API mode: MuAPI /autocrop
+    ├── soundtrack.py             optional Sonilo background music (--music)
     ├── pipeline.py               mode dispatcher (api ↔ local)
     └── local/                    --mode local backends (offline)
         ├── downloader.py         yt-dlp download

--- a/main.py
+++ b/main.py
@@ -31,6 +31,17 @@ def main() -> int:
     parser.add_argument("--aspect-ratio", default="9:16", help="Output aspect ratio (default: 9:16)")
     parser.add_argument("--format", default="720", help="Source download resolution: 360 / 480 / 720 / 1080 (default: 720)")
     parser.add_argument("--language", default=None, help="Force Whisper language code, e.g. 'en' (default: auto-detect)")
+    parser.add_argument(
+        "--music",
+        action="store_true",
+        help="Give each short an original soundtrack matched to the video (Sonilo), "
+        "mixed under the original audio. Off by default; needs SONILO_API_KEY.",
+    )
+    parser.add_argument(
+        "--music-prompt",
+        default=None,
+        help="Optional style hint for --music, e.g. 'lofi hip hop, mellow'",
+    )
     parser.add_argument("--output-json", default=None, help="Write the full result JSON to this path")
     args = parser.parse_args()
 
@@ -42,6 +53,8 @@ def main() -> int:
             download_format=args.format,
             language=args.language,
             mode=args.mode,
+            music=args.music,
+            music_prompt=args.music_prompt,
         )
     except Exception as e:
         print(f"\nFAILED: {e}", file=sys.stderr)
@@ -60,6 +73,8 @@ def main() -> int:
             print(f"     clip:   {s['clip_url']}")
         else:
             print(f"     clip:   FAILED ({s.get('error')})")
+        if s.get("music_path"):
+            print(f"     music:  {s.get('music_title') or s['music_path']}")
 
     if args.output_json:
         with open(args.output_json, "w") as f:

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -10,6 +10,14 @@ MUAPI_BASE_URL = os.getenv("MUAPI_BASE_URL", "https://api.muapi.ai/api/v1").rstr
 POLL_INTERVAL_SECONDS = float(os.getenv("MUAPI_POLL_INTERVAL", "5"))
 POLL_TIMEOUT_SECONDS = float(os.getenv("MUAPI_POLL_TIMEOUT", "600"))
 
+# Sonilo background music (--music) — generates an original soundtrack
+# matched to each rendered short and mixes it under the original audio.
+SONILO_API_KEY = os.getenv("SONILO_API_KEY", "").strip()
+SONILO_API_URL = os.getenv("SONILO_API_URL", "https://api.sonilo.com").rstrip("/")
+SONILO_MUSIC_VOLUME = float(os.getenv("SONILO_MUSIC_VOLUME", "0.3"))
+# Generation streams over a single request; match the backend's read timeout.
+SONILO_TIMEOUT_SECONDS = float(os.getenv("SONILO_TIMEOUT", "600"))
+
 # Local-mode (--mode local) settings — only consulted when running offline.
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
@@ -47,6 +55,16 @@ def require_api_key() -> str:
             "MUAPI_API_KEY is not set. Add it to your .env file or export it as an env var."
         )
     return MUAPI_API_KEY
+
+
+def require_sonilo_key() -> str:
+    if not SONILO_API_KEY:
+        raise RuntimeError(
+            "SONILO_API_KEY is not set. --music needs a Sonilo key. "
+            "Add it to your .env or export it, or drop the --music flag. "
+            "Keys: https://platform.sonilo.com/dashboard/api-keys"
+        )
+    return SONILO_API_KEY
 
 
 def require_openai_key() -> str:

--- a/shorts_generator/pipeline.py
+++ b/shorts_generator/pipeline.py
@@ -14,12 +14,22 @@ from .highlights import call_muapi_llm, get_highlights
 from .transcriber import transcribe
 
 
+def _add_music(shorts: List[Dict], music_prompt: Optional[str], label: str) -> List[Dict]:
+    """Optional Sonilo background-music pass over the rendered shorts."""
+    from .soundtrack import add_music_to_shorts
+
+    print(f"[{label}] adding background music to {len(shorts)} shorts", flush=True)
+    return add_music_to_shorts(shorts, prompt=music_prompt)
+
+
 def _run_local(
     youtube_url: str,
     num_clips: int,
     aspect_ratio: str,
     download_format: str,
     language: Optional[str],
+    music: bool = False,
+    music_prompt: Optional[str] = None,
 ) -> Dict:
     from .local.clipper import crop_highlights_local
     from .local.downloader import download_youtube_local
@@ -44,6 +54,9 @@ def _run_local(
 
     shorts = crop_highlights_local(source_path, top, aspect_ratio=aspect_ratio)
 
+    if music:
+        shorts = _add_music(shorts, music_prompt, "pipeline/local")
+
     return {
         "mode": "local",
         "source_video_url": source_path,
@@ -59,6 +72,8 @@ def _run_api(
     aspect_ratio: str,
     download_format: str,
     language: Optional[str],
+    music: bool = False,
+    music_prompt: Optional[str] = None,
 ) -> Dict:
     source_url = download_youtube(youtube_url, fmt=download_format)
 
@@ -78,6 +93,9 @@ def _run_api(
 
     shorts = crop_highlights(source_url, top, aspect_ratio=aspect_ratio)
 
+    if music:
+        shorts = _add_music(shorts, music_prompt, "pipeline")
+
     return {
         "mode": "api",
         "source_video_url": source_url,
@@ -94,6 +112,8 @@ def generate_shorts(
     download_format: str = "720",
     language: Optional[str] = None,
     mode: str = "api",
+    music: bool = False,
+    music_prompt: Optional[str] = None,
 ) -> Dict:
     """Run the full pipeline and return a structured result.
 
@@ -105,6 +125,10 @@ def generate_shorts(
         language: ISO-639-1 to force Whisper language detection.
         mode: "api" (default, MuAPI) or "local" (yt-dlp + faster-whisper +
             OpenAI or Gemini + ffmpeg).
+        music: opt-in — give each rendered short an original soundtrack
+            matched to the video via Sonilo, mixed under the original audio.
+            Needs SONILO_API_KEY (and ffmpeg on PATH for the mix).
+        music_prompt: optional style hint for the generated music.
 
     Returns:
         {
@@ -115,9 +139,21 @@ def generate_shorts(
           "shorts": [...],           # top `num_clips` with clip_url / local path
         }
     """
+    if music:
+        # Fail fast on a missing key before any (billed) MuAPI work starts.
+        from .config import require_sonilo_key
+
+        require_sonilo_key()
+
     mode = (mode or "api").lower()
     if mode == "local":
-        return _run_local(youtube_url, num_clips, aspect_ratio, download_format, language)
+        return _run_local(
+            youtube_url, num_clips, aspect_ratio, download_format, language,
+            music=music, music_prompt=music_prompt,
+        )
     if mode == "api":
-        return _run_api(youtube_url, num_clips, aspect_ratio, download_format, language)
+        return _run_api(
+            youtube_url, num_clips, aspect_ratio, download_format, language,
+            music=music, music_prompt=music_prompt,
+        )
     raise ValueError(f"Unknown mode: {mode!r}. Use 'api' or 'local'.")

--- a/shorts_generator/soundtrack.py
+++ b/shorts_generator/soundtrack.py
@@ -1,0 +1,286 @@
+"""Optional background music via Sonilo (--music).
+
+After a short is rendered, the finished clip is uploaded to Sonilo's
+``/v1/video-to-music`` endpoint, which analyzes the clip's pacing, motion, and
+emotion and returns an original soundtrack matched to the video (AAC in an
+.m4a container, same duration as the clip). The track is then mixed under the
+clip's existing audio with ffmpeg at low volume so the speech stays fully
+intelligible. Generated tracks are licensed and safe for commercial use
+(terms apply).
+
+Fully opt-in: nothing here runs unless ``--music`` is passed, and it needs
+``SONILO_API_KEY``. Any per-clip failure (API error, missing ffmpeg, clip over
+the endpoint's duration limit) is logged and that short ships with its
+original audio — the pipeline never fails because music generation did.
+
+The endpoint streams NDJSON events over a single POST:
+  * ``audio_chunk`` — base64 audio bytes, aggregated per ``stream_index``
+  * ``title``       — optional track title
+  * ``complete``    — terminal success
+  * ``error``       — terminal failure
+Progress events (``stage_start``, ...) and unparseable lines are ignored.
+"""
+import base64
+import binascii
+import json
+import os
+import shutil
+import subprocess
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import requests
+
+from .config import (
+    LOCAL_OUTPUT_DIR,
+    SONILO_API_URL,
+    SONILO_MUSIC_VOLUME,
+    SONILO_TIMEOUT_SECONDS,
+    require_sonilo_key,
+)
+
+SONILO_VIDEO_TO_MUSIC_PATH = "/v1/video-to-music"
+
+# The endpoint rejects videos longer than 6 minutes. Shorts are well under
+# that, but check locally first (best-effort, via ffprobe) so an oversized
+# clip is skipped instead of wasting an upload the backend will reject.
+MAX_VIDEO_DURATION_SECONDS = 360
+
+
+class SoniloError(RuntimeError):
+    pass
+
+
+def _error_detail(body: str) -> str:
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return body
+    if isinstance(parsed, dict):
+        detail = parsed.get("message") or parsed.get("detail") or parsed.get("error")
+        if isinstance(detail, str) and detail.strip():
+            return detail.strip()
+    return body
+
+
+def _http_error_message(status_code: int, body: str) -> str:
+    detail = _error_detail(body)
+    if status_code == 401:
+        return "Invalid SONILO_API_KEY — check the key in your .env"
+    if status_code == 402:
+        return detail or "Sonilo account is out of credit"
+    if status_code == 413:
+        return f"upload too large: {detail}"
+    if status_code == 429:
+        return f"Sonilo rate limit hit: {detail}"
+    return f"Sonilo API error ({status_code}): {detail}"
+
+
+def _consume_ndjson(lines: Iterable[str]) -> Tuple[bytes, Optional[str]]:
+    """Consume the NDJSON event stream; return (audio bytes, optional title).
+
+    Audio chunks are aggregated per stream_index; the first stream is returned.
+    """
+    streams: Dict[int, bytearray] = {}
+    title: Optional[str] = None
+    completed = False
+    for line in lines:
+        if not line or not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type == "audio_chunk":
+            data = event.get("data")
+            if not isinstance(data, str):
+                continue
+            try:
+                index = int(event.get("stream_index", 0))
+            except (TypeError, ValueError):
+                continue
+            if index < 0:
+                continue
+            try:
+                decoded = base64.b64decode(data, validate=True)
+            except (binascii.Error, ValueError):
+                continue
+            streams.setdefault(index, bytearray()).extend(decoded)
+        elif event_type == "title":
+            value = event.get("title")
+            if isinstance(value, str) and value.strip():
+                title = value.strip()
+        elif event_type == "complete":
+            completed = True
+        elif event_type == "error":
+            message = event.get("message") or event.get("code") or "stream error"
+            raise SoniloError(f"music generation failed: {message}")
+        # stage_start / stage_complete / other progress events are ignored.
+
+    if not completed:
+        raise SoniloError("music stream ended unexpectedly (no complete event)")
+    if not streams:
+        raise SoniloError("music stream completed but returned no audio")
+    first_index = sorted(streams)[0]
+    return bytes(streams[first_index]), title
+
+
+def generate_music(video_path: str, prompt: str = "") -> Tuple[bytes, Optional[str]]:
+    """Upload one rendered short and return (m4a audio bytes, optional title)."""
+    api_key = require_sonilo_key()
+    url = f"{SONILO_API_URL}{SONILO_VIDEO_TO_MUSIC_PATH}"
+    data = {"prompt": prompt.strip()} if prompt and prompt.strip() else None
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        with open(video_path, "rb") as fh:
+            files = {"video": (os.path.basename(video_path), fh, "video/mp4")}
+            # The generation endpoint is non-idempotent (it bills per call),
+            # so unlike muapi.submit there is no retry here.
+            resp = requests.post(
+                url,
+                headers=headers,
+                data=data,
+                files=files,
+                stream=True,
+                timeout=SONILO_TIMEOUT_SECONDS,
+            )
+    except requests.Timeout as e:
+        raise SoniloError(f"music generation timed out ({SONILO_TIMEOUT_SECONDS:.0f}s)") from e
+    except requests.ConnectionError as e:
+        raise SoniloError(f"could not reach Sonilo: {e}") from e
+
+    with resp:
+        if resp.status_code >= 400:
+            raise SoniloError(_http_error_message(resp.status_code, resp.text))
+        try:
+            return _consume_ndjson(resp.iter_lines(decode_unicode=True))
+        except requests.RequestException as e:
+            raise SoniloError(f"music stream failed: {e}") from e
+
+
+def _probe_duration(video_path: str) -> Optional[float]:
+    """Best-effort duration check via ffprobe; None if it can't be determined."""
+    if shutil.which("ffprobe") is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                "ffprobe", "-v", "quiet",
+                "-print_format", "json",
+                "-show_format",
+                video_path,
+            ],
+            capture_output=True,
+            timeout=30,
+        )
+        return float(json.loads(proc.stdout)["format"]["duration"])
+    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return None
+
+
+def _mix_music(video_path: str, music_path: str, out_path: str, volume: float) -> str:
+    """ffmpeg-mix the generated track under the clip's original audio.
+
+    The original speech stays at full volume; the music sits under it at
+    `volume` (default 0.3). Video stream is copied untouched.
+    """
+    filter_complex = (
+        f"[1:a]volume={volume}[bgm];"
+        "[0:a][bgm]amix=inputs=2:duration=first:dropout_transition=0[mix]"
+    )
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-i", video_path,
+        "-i", music_path,
+        "-filter_complex", filter_complex,
+        "-map", "0:v:0", "-map", "[mix]",
+        "-c:v", "copy",
+        "-c:a", "aac", "-b:a", "128k",
+        out_path,
+    ]
+    subprocess.run(cmd, check=True)
+    return out_path
+
+
+def _ensure_local_clip(clip_url: str, out_dir: str, index: int) -> str:
+    """Return a local path for the clip, downloading it first if it's remote.
+
+    API-mode shorts are hosted URLs; music mixing runs locally, so the clip is
+    fetched into `out_dir` (same place local mode writes its shorts).
+    """
+    if not clip_url.startswith(("http://", "https://")):
+        return clip_url
+    os.makedirs(out_dir, exist_ok=True)
+    local_path = os.path.join(out_dir, f"short_{index:02d}.mp4")
+    print(f"[music] downloading clip {index} for mixing", flush=True)
+    with requests.get(clip_url, stream=True, timeout=SONILO_TIMEOUT_SECONDS) as resp:
+        resp.raise_for_status()
+        with open(local_path, "wb") as fh:
+            for chunk in resp.iter_content(chunk_size=1 << 20):
+                fh.write(chunk)
+    return local_path
+
+
+def add_music_to_short(short: Dict, index: int, out_dir: str, prompt: str = "") -> Dict:
+    """Generate + mix music for one short; returns the updated dict. Raises on failure."""
+    # ffmpeg is needed for the mix — check before the (billed) generation call.
+    if shutil.which("ffmpeg") is None:
+        raise SoniloError("ffmpeg not found on PATH (required to mix the music)")
+
+    local_path = _ensure_local_clip(short["clip_url"], out_dir, index)
+
+    duration = _probe_duration(local_path)
+    if duration is not None and duration > MAX_VIDEO_DURATION_SECONDS:
+        raise SoniloError(
+            f"clip is {duration:.0f}s, over the {MAX_VIDEO_DURATION_SECONDS}s "
+            "limit for music generation"
+        )
+
+    audio, title = generate_music(local_path, prompt=prompt)
+
+    music_path = os.path.splitext(local_path)[0] + ".music.m4a"
+    with open(music_path, "wb") as fh:
+        fh.write(audio)
+
+    tmp_path = local_path + ".tmp.mp4"
+    try:
+        _mix_music(local_path, music_path, tmp_path, SONILO_MUSIC_VOLUME)
+        os.replace(tmp_path, local_path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    updated = {**short, "music_path": music_path}
+    if title:
+        updated["music_title"] = title
+    if local_path != short["clip_url"]:
+        updated["source_clip_url"] = short["clip_url"]
+        updated["clip_url"] = local_path
+    return updated
+
+
+def add_music_to_shorts(
+    shorts: List[Dict],
+    prompt: Optional[str] = None,
+    out_dir: Optional[str] = None,
+) -> List[Dict]:
+    """Add background music to every rendered short.
+
+    Mirrors crop_highlights' failure policy: a failed clip is logged and kept
+    as-is (original audio, no music keys) instead of failing the run.
+    """
+    out_dir = out_dir or LOCAL_OUTPUT_DIR
+    results: List[Dict] = []
+    for i, short in enumerate(shorts, 1):
+        if not short.get("clip_url"):
+            results.append(short)  # cropping already failed for this one
+            continue
+        print(f"[music] {i}/{len(shorts)}: {short.get('title', '(untitled)')}", flush=True)
+        try:
+            results.append(add_music_to_short(short, i, out_dir, prompt=prompt or ""))
+        except Exception as e:
+            print(f"[music] {i} failed: {e} — keeping the short without music", flush=True)
+            results.append(short)
+    return results

--- a/tests/test_soundtrack.py
+++ b/tests/test_soundtrack.py
@@ -1,0 +1,314 @@
+"""Tests for the optional Sonilo background-music step (--music).
+
+All tests run offline — no network, no ffmpeg/ffprobe, no real API key.
+The Sonilo HTTP calls and the ffmpeg mix are stubbed; the tests assert the
+wiring: Bearer auth, multipart upload, prompt forwarding, NDJSON event
+handling, the duration pre-check, and the ship-without-music failure policy.
+"""
+import base64
+import importlib
+import json
+
+import pytest
+
+
+def _load_soundtrack(monkeypatch, **env):
+    """Reload config + soundtrack after setting env (both bind at import time)."""
+    monkeypatch.setenv("SONILO_API_KEY", "test-key")
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    from shorts_generator import config
+    importlib.reload(config)
+    from shorts_generator import soundtrack
+    importlib.reload(soundtrack)
+    return soundtrack
+
+
+def _chunk_line(data: bytes, index: int = 0) -> str:
+    return json.dumps({
+        "type": "audio_chunk",
+        "stream_index": index,
+        "data": base64.b64encode(data).decode(),
+    })
+
+
+# ---------- NDJSON stream consumer ----------
+
+def test_consume_ndjson_aggregates_chunks_and_title(monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    lines = [
+        json.dumps({"type": "stage_start", "stage": "analysis"}),  # ignored
+        _chunk_line(b"AB"),
+        "not json at all",                                          # ignored
+        json.dumps(["not", "a", "dict"]),                           # ignored
+        json.dumps({"type": "audio_chunk", "stream_index": 0, "data": "!!!"}),  # bad b64, ignored
+        json.dumps({"type": "audio_chunk", "stream_index": -1, "data": base64.b64encode(b"x").decode()}),  # ignored
+        _chunk_line(b"CD"),
+        _chunk_line(b"ZZ", index=1),  # second stream — not returned
+        json.dumps({"type": "title", "title": "Neon Drift"}),
+        json.dumps({"type": "complete"}),
+    ]
+    audio, title = soundtrack._consume_ndjson(lines)
+    assert audio == b"ABCD"
+    assert title == "Neon Drift"
+
+
+def test_consume_ndjson_error_event_raises(monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    lines = [json.dumps({"type": "error", "message": "generation blew up"})]
+    with pytest.raises(soundtrack.SoniloError, match="generation blew up"):
+        soundtrack._consume_ndjson(lines)
+
+
+def test_consume_ndjson_requires_complete_event(monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    with pytest.raises(soundtrack.SoniloError, match="ended unexpectedly"):
+        soundtrack._consume_ndjson([_chunk_line(b"AB")])
+
+
+def test_consume_ndjson_requires_audio(monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    with pytest.raises(soundtrack.SoniloError, match="no audio"):
+        soundtrack._consume_ndjson([json.dumps({"type": "complete"})])
+
+
+# ---------- config ----------
+
+def test_missing_key_raises(monkeypatch):
+    monkeypatch.setenv("SONILO_API_KEY", "")
+    from shorts_generator import config
+    importlib.reload(config)
+    with pytest.raises(RuntimeError, match="SONILO_API_KEY"):
+        config.require_sonilo_key()
+
+
+# ---------- generate_music HTTP wiring ----------
+
+class _FakeStreamResponse:
+    def __init__(self, lines, status_code=200, text=""):
+        self._lines = lines
+        self.status_code = status_code
+        self.text = text
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def iter_lines(self, decode_unicode=False):
+        return iter(self._lines)
+
+
+def test_generate_music_sends_bearer_and_multipart(tmp_path, monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+
+    video = tmp_path / "short_01.mp4"
+    video.write_bytes(b"not-a-real-mp4")
+
+    recorded = {}
+
+    def fake_post(url, headers=None, data=None, files=None, stream=None, timeout=None):
+        recorded.update(url=url, headers=headers, data=data, files=files, stream=stream)
+        return _FakeStreamResponse([
+            _chunk_line(b"MUSIC"),
+            json.dumps({"type": "title", "title": "Golden Hour"}),
+            json.dumps({"type": "complete"}),
+        ])
+
+    monkeypatch.setattr(soundtrack.requests, "post", fake_post)
+
+    audio, title = soundtrack.generate_music(str(video), prompt="lofi hip hop")
+
+    assert audio == b"MUSIC"
+    assert title == "Golden Hour"
+    assert recorded["url"].endswith("/v1/video-to-music")
+    assert recorded["headers"]["Authorization"] == "Bearer test-key"
+    assert recorded["data"] == {"prompt": "lofi hip hop"}
+    assert recorded["stream"] is True
+    name, fh, mime = recorded["files"]["video"]
+    assert name == "short_01.mp4"
+    assert mime == "video/mp4"
+
+
+def test_generate_music_omits_empty_prompt(tmp_path, monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    video = tmp_path / "short_01.mp4"
+    video.write_bytes(b"x")
+
+    recorded = {}
+
+    def fake_post(url, **kwargs):
+        recorded.update(kwargs)
+        return _FakeStreamResponse([_chunk_line(b"M"), json.dumps({"type": "complete"})])
+
+    monkeypatch.setattr(soundtrack.requests, "post", fake_post)
+    soundtrack.generate_music(str(video), prompt="   ")
+    assert recorded["data"] is None
+
+
+def test_generate_music_maps_http_errors(tmp_path, monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    video = tmp_path / "short_01.mp4"
+    video.write_bytes(b"x")
+
+    def fake_post(url, **kwargs):
+        return _FakeStreamResponse(
+            [], status_code=402, text=json.dumps({"message": "out of credit"})
+        )
+
+    monkeypatch.setattr(soundtrack.requests, "post", fake_post)
+    with pytest.raises(soundtrack.SoniloError, match="out of credit"):
+        soundtrack.generate_music(str(video))
+
+
+# ---------- add_music_to_shorts orchestration ----------
+
+def _stub_tooling(monkeypatch, soundtrack, duration=42.0):
+    """Pretend ffmpeg/ffprobe exist and the clip has a known duration."""
+    monkeypatch.setattr(soundtrack.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(soundtrack, "_probe_duration", lambda path: duration)
+
+
+def test_full_flow_mixes_in_place_and_keeps_track(tmp_path, monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    _stub_tooling(monkeypatch, soundtrack)
+
+    video = tmp_path / "short_01.mp4"
+    video.write_bytes(b"ORIGINAL")
+
+    recorded = {}
+
+    def fake_generate(video_path, prompt=""):
+        recorded["generate"] = {"video_path": video_path, "prompt": prompt}
+        return b"AUDIO", "Neon Drift"
+
+    def fake_mix(video_path, music_path, out_path, volume):
+        recorded["mix"] = {"volume": volume}
+        with open(out_path, "wb") as fh:
+            fh.write(b"MIXED")
+        return out_path
+
+    monkeypatch.setattr(soundtrack, "generate_music", fake_generate)
+    monkeypatch.setattr(soundtrack, "_mix_music", fake_mix)
+
+    shorts = [{"title": "hook", "clip_url": str(video)}]
+    out = soundtrack.add_music_to_shorts(shorts, prompt="lofi", out_dir=str(tmp_path))
+
+    assert recorded["generate"]["prompt"] == "lofi"
+    assert recorded["mix"]["volume"] == pytest.approx(0.3)
+    # The mixed file replaces the original path — clip_url stays stable.
+    assert out[0]["clip_url"] == str(video)
+    assert video.read_bytes() == b"MIXED"
+    assert "source_clip_url" not in out[0]
+    # The generated track is kept beside the short for remixing.
+    music = tmp_path / "short_01.music.m4a"
+    assert out[0]["music_path"] == str(music)
+    assert music.read_bytes() == b"AUDIO"
+    assert out[0]["music_title"] == "Neon Drift"
+
+
+def test_remote_clip_downloaded_before_upload(tmp_path, monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    _stub_tooling(monkeypatch, soundtrack)
+
+    class _FakeGetResponse:
+        status_code = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=None):
+            return iter([b"REMOTE-CLIP"])
+
+    monkeypatch.setattr(soundtrack.requests, "get", lambda url, **kw: _FakeGetResponse())
+    monkeypatch.setattr(soundtrack, "generate_music", lambda path, prompt="": (b"AUDIO", None))
+
+    def fake_mix(video_path, music_path, out_path, volume):
+        with open(out_path, "wb") as fh:
+            fh.write(b"MIXED")
+        return out_path
+
+    monkeypatch.setattr(soundtrack, "_mix_music", fake_mix)
+
+    remote = "https://cdn.example.com/clips/short_1.mp4"
+    out = soundtrack.add_music_to_shorts(
+        [{"title": "t", "clip_url": remote}], out_dir=str(tmp_path)
+    )
+
+    local = tmp_path / "short_01.mp4"
+    assert out[0]["clip_url"] == str(local)
+    assert out[0]["source_clip_url"] == remote
+    assert local.read_bytes() == b"MIXED"
+    assert "music_title" not in out[0]  # no title event → no key
+
+
+def test_failure_ships_short_unchanged(tmp_path, monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    _stub_tooling(monkeypatch, soundtrack)
+
+    video = tmp_path / "short_01.mp4"
+    video.write_bytes(b"ORIGINAL")
+
+    def failing_generate(video_path, prompt=""):
+        raise soundtrack.SoniloError("Sonilo rate limit hit: slow down")
+
+    monkeypatch.setattr(soundtrack, "generate_music", failing_generate)
+
+    short = {"title": "t", "clip_url": str(video), "score": 90}
+    out = soundtrack.add_music_to_shorts([short], out_dir=str(tmp_path))
+
+    assert out == [short]  # untouched — no music keys, no exception
+    assert video.read_bytes() == b"ORIGINAL"
+
+
+def test_duration_cap_skips_generation(tmp_path, monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    _stub_tooling(monkeypatch, soundtrack, duration=400.0)  # over the 360s cap
+
+    video = tmp_path / "short_01.mp4"
+    video.write_bytes(b"ORIGINAL")
+
+    called = {}
+    monkeypatch.setattr(
+        soundtrack, "generate_music",
+        lambda *a, **kw: called.setdefault("generate", True),
+    )
+
+    short = {"title": "t", "clip_url": str(video)}
+    out = soundtrack.add_music_to_shorts([short], out_dir=str(tmp_path))
+
+    assert "generate" not in called  # never uploaded, never billed
+    assert out == [short]
+
+
+def test_missing_ffmpeg_skips_generation(tmp_path, monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    monkeypatch.setattr(soundtrack.shutil, "which", lambda name: None)
+
+    video = tmp_path / "short_01.mp4"
+    video.write_bytes(b"ORIGINAL")
+
+    called = {}
+    monkeypatch.setattr(
+        soundtrack, "generate_music",
+        lambda *a, **kw: called.setdefault("generate", True),
+    )
+
+    short = {"title": "t", "clip_url": str(video)}
+    out = soundtrack.add_music_to_shorts([short], out_dir=str(tmp_path))
+
+    assert "generate" not in called  # ffmpeg checked before the billed call
+    assert out == [short]
+
+
+def test_failed_crop_passes_through(monkeypatch):
+    soundtrack = _load_soundtrack(monkeypatch)
+    short = {"title": "t", "clip_url": None, "error": "autocrop failed"}
+    assert soundtrack.add_music_to_shorts([short]) == [short]


### PR DESCRIPTION
Disclosure: I work on Sonilo.

## What this adds

An opt-in post-assembly step: pass `--music` and each rendered short gets an original soundtrack matched to the video. The finished clip is uploaded to [Sonilo](https://sonilo.com)'s `/v1/video-to-music` endpoint, which analyzes the clip's pacing, motion, and emotion and returns a track the same length as the clip. The track is then mixed **under** the clip's existing audio with ffmpeg at low volume (default 0.3, `SONILO_MUSIC_VOLUME`). Shorts are speech-first, so the original audio stays fully intelligible. Generated tracks are licensed and safe for commercial use (terms apply).

## Opt-in / non-breaking

- Off by default. Runs only with `--music` **and** the user's own `SONILO_API_KEY`; the key is checked up front so a misconfigured run fails before any billed work starts.
- Zero new dependencies: the client uses `requests`, already a core dep. Mixing uses ffmpeg (already required for `--mode local`).
- Same failure policy as `crop_highlights`: any per-clip failure (API error, missing ffmpeg, clip over the endpoint's 6-minute limit, pre-checked locally via ffprobe before uploading) is logged and that short ships with its original audio. The run never fails because music generation did.
- Works in both modes: local shorts are mixed in place (`clip_url` stays stable); API-mode clips are downloaded to `LOCAL_OUTPUT_DIR` first (hosted URL kept as `source_clip_url`). The track is also saved as `short_XX.music.m4a` for remixing at a different volume without regenerating.

## Files

- `shorts_generator/soundtrack.py` (new): streaming client (single POST, NDJSON events) + ffmpeg mix
- `shorts_generator/config.py`: `SONILO_*` settings + `require_sonilo_key()`
- `shorts_generator/pipeline.py` / `main.py`: `--music` / `--music-prompt` plumbing in both modes
- `.env.example`, `README.md`: docs
- `tests/test_soundtrack.py`: tests

## How it was tested

- `pytest tests/`: 14 passing, fully offline (no network, no ffmpeg, no key needed). Covers the NDJSON consumer (chunk aggregation, title, error/incomplete streams, malformed lines), Bearer + multipart + prompt wiring, HTTP error mapping, in-place mix + sidecar track, the remote-clip download path, duration cap and missing-ffmpeg checks happening before the billed call, and the ship-without-music failure policy.
- `python3 -m compileall` clean; CLI `--help` and the missing-key fail-fast verified by hand.
- Honest note: I have not run a live end-to-end generation from this repo's pipeline in this branch. The HTTP layer is a direct port of a production Sonilo client I maintain (same endpoint, same event contract), and the tests pin that contract. Happy to attach a live sample output if useful.