### PR TITLE
Fix WinError 32 file lock on Windows during clip cleanup

### DIFF
--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -5,6 +5,6 @@ yt-dlp>=2024.1.1
 faster-whisper>=1.0.0
 openai>=1.0.0
 google-genai>=1.0.0
-opencv-python>=4.8.0
+opencv-python>=4.8.0,<5.0.0
 # torch is only needed if you want CUDA Whisper. CPU works without it.
 # torch>=2.0

--- a/shorts_generator/local/clipper.py
+++ b/shorts_generator/local/clipper.py
@@ -7,6 +7,7 @@ Two stages per highlight:
      cascade — same approach as the original repo, no external models).
 """
 import os
+import time 
 import subprocess
 from typing import Dict, List, Optional, Tuple
 
@@ -135,8 +136,13 @@ def crop_clip_local(
         _cut_subclip(source_path, start_time, end_time, cut_path)
         _reframe_vertical(cut_path, out_path, aspect_ratio)
     finally:
-        if os.path.exists(cut_path):
-            os.remove(cut_path)
+        for attempt in range(5):
+            try:
+                if os.path.exists(cut_path):
+                    os.remove(cut_path)
+                break
+            except PermissionError:
+                time.sleep(0.5)
     return out_path
 
 


### PR DESCRIPTION
What broke

On Windows, --mode local clip generation intermittently fails with:

[WinError 32] The process cannot access the file because it is being used by another process: 'output\short_XX.mp4.cut.mp4'

This happens during cleanup in crop_clip_local(), when the code tries to delete the intermediate .cut.mp4 file right after _reframe_vertical() finishes processing it with OpenCV.

Why it happens

cv2.VideoCapture.release() doesn't always release the underlying file handle instantly on Windows — there's a small delay before the OS actually frees the lock. The existing code calls os.remove(cut_path) immediately afterward in the finally block, so it can race against that delay and hit a permission error.

Fix

Wrapped the cleanup in a small retry loop — up to 5 attempts with a 0.5s delay between each — giving Windows enough time to release the handle before deletion is attempted again. Falls through silently once the file is successfully removed.

Testing

Tested on Windows 11 with a local video (5:46 min), generating 3 clips end-to-end with --mode local. Before the fix: all 3 clips failed with WinError 32. After the fix: all 3 clips generated successfully with no errors.


----------------------------------------------------------------------------------------------------------------------------------------

Fix 2: Pin OpenCV to avoid CascadeClassifier breakage

What broke: requirements-local.txt specifies opencv-python>=4.8.0 with no upper bound. On a fresh install, pip resolved this to OpenCV 5.0.0 (a new major release), which restructured/moved CascadeClassifier, causing:

AttributeError: module 'cv2' has no attribute 'CascadeClassifier'

This breaks the face-tracking vertical crop step entirely on any fresh pip install -r requirements-local.txt.

Fix: Pinned the dependency to opencv-python>=4.8.0,<5.0.0 in requirements-local.txt, keeping installs on the stable 4.x line where CascadeClassifier still exists at its expected location.