### PR TITLE
feat: add LiteLLM as a AI Gateway provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,18 @@
 MUAPI_API_KEY=your_muapi_key_here
 
 # Local mode (--mode local)
-LLM_PROVIDER=openai           # openai or gemini
+LLM_PROVIDER=openai           # openai, gemini, or litellm
 OPENAI_API_KEY=your_openai_key_here
 OPENAI_MODEL=gpt-4o-mini
 GEMINI_API_KEY=your_gemini_key_here
 GEMINI_MODEL=gemini-2.5-flash
+# LiteLLM gateway (LLM_PROVIDER=litellm): one interface to 100+ providers / a proxy.
+# LITELLM_MODEL is any LiteLLM model string; the key/base URL are optional (blank
+# key falls back to the upstream provider's own env var; set the base URL only for
+# a LiteLLM proxy).
+LITELLM_MODEL=gpt-4o-mini
+LITELLM_API_KEY=
+LITELLM_BASE_URL=
 LOCAL_WHISPER_MODEL=base
 LOCAL_WHISPER_DEVICE=auto
 LOCAL_OUTPUT_DIR=output

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built for creators, agencies, and developers who don't want to pay $20–$300/mo
 ## Features
 
 - **🎬 YouTube In, Vertical Out**: Hand it any YouTube URL — get back N viral-ready 9:16 mp4s
-- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, and `ffmpeg`/`opencv`, and lets you pick OpenAI or Gemini for highlight ranking
+- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, and `ffmpeg`/`opencv`, and lets you pick OpenAI, Gemini, or LiteLLM (100+ providers / self-hosted proxy) for highlight ranking
 - **🤖 Virality-Aware Highlight Selection**: Clips ranked on hooks, emotional peaks, opinion bombs, revelation moments, conflict, quotable lines, story peaks, and practical value — not just generic "interesting"
 - **📈 Score + Hook + Reason for Every Clip**: Each highlight comes with a viral score, an opening hook line, and a one-sentence explanation of why it works
 - **🎤 Whisper Transcription, Your Choice**: Cloud (`/openai-whisper` via MuAPI) or local (`faster-whisper`, CPU or CUDA) — same downstream output shape
@@ -64,7 +64,7 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
 
 - Python 3.10+
 - For **API mode (default)**: a MuAPI key — powers download, transcription, highlight ranking, and clipping in a single dependency
-- For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an LLM API key (`OPENAI_API_KEY` or `GEMINI_API_KEY`; only the LLM step is remote)
+- For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an LLM API key (`OPENAI_API_KEY`, `GEMINI_API_KEY`, or — with `LLM_PROVIDER=litellm` — any provider key LiteLLM supports; only the LLM step is remote)
 
 ### Steps
 
@@ -95,11 +95,15 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
    MUAPI_API_KEY=your_muapi_key_here
 
    # Local mode (--mode local)
-   LLM_PROVIDER=openai         # openai or gemini
+   LLM_PROVIDER=openai         # openai, gemini, or litellm
    OPENAI_API_KEY=your_openai_key_here
    OPENAI_MODEL=gpt-4o-mini          # optional, default gpt-4o-mini
    GEMINI_API_KEY=your_gemini_key_here
    GEMINI_MODEL=gemini-2.5-flash      # optional, default gemini-2.5-flash
+   # LiteLLM gateway (LLM_PROVIDER=litellm) — 100+ providers or a self-hosted proxy:
+   LITELLM_MODEL=gpt-4o-mini          # any LiteLLM model string (e.g. anthropic/claude-sonnet-4-5)
+   LITELLM_API_KEY=                   # optional; blank uses the upstream provider's own env key
+   LITELLM_BASE_URL=                  # optional; set to a LiteLLM proxy URL to route through it
    LOCAL_WHISPER_MODEL=base          # tiny / base / small / medium / large-v3
    LOCAL_WHISPER_DEVICE=auto         # auto / cpu / cuda
    LOCAL_OUTPUT_DIR=output           # where local mp4s land
@@ -188,7 +192,7 @@ xargs -a urls.txt -I{} python main.py "{}"
 |---|---|---|
 | Download | MuAPI `/youtube-download` | `yt-dlp` for remote URLs, direct file path for local inputs |
 | Transcription | MuAPI `/openai-whisper` | `faster-whisper` (CPU or CUDA) |
-| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default) |
+| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default), `LLM_PROVIDER=litellm` routes through LiteLLM to 100+ providers or a self-hosted proxy (`LITELLM_MODEL`) |
 | Vertical crop | MuAPI `/autocrop` | `ffmpeg` + OpenCV face tracking |
 | Output | hosted URLs | local mp4 paths |
 | Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY` or `GEMINI_API_KEY` (+ `ffmpeg` on PATH) |

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -5,6 +5,7 @@ yt-dlp>=2024.1.1
 faster-whisper>=1.0.0
 openai>=1.0.0
 google-genai>=1.0.0
+litellm>=1.85,<1.96
 opencv-python>=4.8.0
 # torch is only needed if you want CUDA Whisper. CPU works without it.
 # torch>=2.0

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -15,6 +15,15 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "").strip()
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+# LiteLLM gateway (LLM_PROVIDER=litellm) — one interface to 100+ providers or a
+# self-hosted proxy. LITELLM_MODEL is a LiteLLM model string (e.g. "gpt-4o-mini",
+# "anthropic/claude-sonnet-4-5", "gemini/gemini-2.5-flash"). LITELLM_API_KEY and
+# LITELLM_BASE_URL are optional: leave the key blank to let LiteLLM read the
+# upstream provider's own env var (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...), and
+# set the base URL only when routing through a LiteLLM proxy.
+LITELLM_MODEL = os.getenv("LITELLM_MODEL", "gpt-4o-mini")
+LITELLM_API_KEY = os.getenv("LITELLM_API_KEY", "").strip()
+LITELLM_BASE_URL = os.getenv("LITELLM_BASE_URL", "").strip()
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda

--- a/shorts_generator/local/llm.py
+++ b/shorts_generator/local/llm.py
@@ -1,6 +1,9 @@
-"""Local LLM backend — OpenAI or Gemini, selected by LLM_PROVIDER."""
+"""Local LLM backend — OpenAI, Gemini, or LiteLLM, selected by LLM_PROVIDER."""
 from ..config import (
     GEMINI_MODEL,
+    LITELLM_API_KEY,
+    LITELLM_BASE_URL,
+    LITELLM_MODEL,
     LLM_PROVIDER,
     OPENAI_MODEL,
     require_gemini_key,
@@ -50,6 +53,41 @@ def call_gemini_llm(prompt: str) -> str:
     return response.text or ""
 
 
+def call_litellm_llm(prompt: str) -> str:
+    """LiteLLM gateway backend used by --mode local when LLM_PROVIDER=litellm.
+
+    Routes highlight ranking through LiteLLM's unified interface, so the same
+    prompt can target 100+ providers (OpenAI, Anthropic, Gemini, Bedrock, Azure,
+    self-hosted, ...) or a self-hosted LiteLLM proxy by changing LITELLM_MODEL /
+    LITELLM_BASE_URL instead of touching code.
+    """
+    try:
+        import litellm  # type: ignore
+    except ImportError as e:
+        raise RuntimeError(
+            "litellm is required for LLM_PROVIDER=litellm. Install it with:\n"
+            "    pip install -r requirements-local.txt"
+        ) from e
+
+    kwargs = {
+        "model": LITELLM_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.7,
+        # Silently drop params an upstream provider doesn't accept (e.g. a fixed
+        # temperature on some reasoning models) so one call works across providers.
+        "drop_params": True,
+    }
+    # Forward credentials only when set; blank lets LiteLLM fall back to the
+    # upstream provider's own env var (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...).
+    if LITELLM_API_KEY:
+        kwargs["api_key"] = LITELLM_API_KEY
+    if LITELLM_BASE_URL:
+        kwargs["api_base"] = LITELLM_BASE_URL
+
+    response = litellm.completion(**kwargs)
+    return response.choices[0].message.content or ""  # type: ignore[union-attr]
+
+
 def call_local_llm(prompt: str) -> str:
     """Dispatch to the configured local LLM provider."""
     provider = (LLM_PROVIDER or "openai").strip().lower()
@@ -57,6 +95,8 @@ def call_local_llm(prompt: str) -> str:
         return call_openai_llm(prompt)
     if provider == "gemini":
         return call_gemini_llm(prompt)
+    if provider == "litellm":
+        return call_litellm_llm(prompt)
     raise RuntimeError(
-        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai' or 'gemini'."
+        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai', 'gemini', or 'litellm'."
     )

--- a/tests/test_litellm_backend.py
+++ b/tests/test_litellm_backend.py
@@ -1,0 +1,77 @@
+"""Unit tests for the LiteLLM local backend (LLM_PROVIDER=litellm).
+
+Runs without the real `litellm` package installed: a lightweight stub is
+injected into sys.modules so the tests exercise the dispatch + call shaping
+in shorts_generator/local/llm.py in isolation.
+
+    python -m unittest tests.test_litellm_backend
+"""
+import sys
+import types
+import unittest
+from unittest import mock
+
+# Inject a stub `litellm` before importing the backend so `import litellm`
+# inside call_litellm_llm resolves to this stub (hermetic — never the real dep).
+_litellm_stub = types.ModuleType("litellm")
+_litellm_stub.completion = mock.MagicMock(name="litellm.completion")  # type: ignore[attr-defined]
+sys.modules["litellm"] = _litellm_stub
+
+from shorts_generator.local import llm  # noqa: E402
+
+
+def _fake_response(text: str):
+    """Mimic the ModelResponse.choices[0].message.content shape."""
+    message = types.SimpleNamespace(content=text)
+    choice = types.SimpleNamespace(message=message)
+    return types.SimpleNamespace(choices=[choice])
+
+
+class LiteLLMBackendTest(unittest.TestCase):
+    def setUp(self):
+        self.completion = _litellm_stub.completion
+        self.completion.reset_mock()
+        self.completion.return_value = _fake_response('{"ok": true}')
+
+    def test_call_litellm_llm_shapes_the_request(self):
+        with mock.patch.object(llm, "LITELLM_MODEL", "anthropic/claude-sonnet-4-5"), \
+                mock.patch.object(llm, "LITELLM_API_KEY", ""), \
+                mock.patch.object(llm, "LITELLM_BASE_URL", ""):
+            out = llm.call_litellm_llm("hello")
+
+        self.assertEqual(out, '{"ok": true}')
+        self.completion.assert_called_once()
+        kwargs = self.completion.call_args.kwargs
+        self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4-5")
+        self.assertEqual(kwargs["messages"], [{"role": "user", "content": "hello"}])
+        # drop_params keeps one call portable across providers.
+        self.assertTrue(kwargs["drop_params"])
+        # Blank creds must be OMITTED so LiteLLM falls back to the upstream env var.
+        self.assertNotIn("api_key", kwargs)
+        self.assertNotIn("api_base", kwargs)
+
+    def test_credentials_forwarded_when_set(self):
+        with mock.patch.object(llm, "LITELLM_MODEL", "gpt-4o-mini"), \
+                mock.patch.object(llm, "LITELLM_API_KEY", "sk-proxy"), \
+                mock.patch.object(llm, "LITELLM_BASE_URL", "http://localhost:4000/v1"):
+            llm.call_litellm_llm("hi")
+
+        kwargs = self.completion.call_args.kwargs
+        self.assertEqual(kwargs["api_key"], "sk-proxy")
+        self.assertEqual(kwargs["api_base"], "http://localhost:4000/v1")
+
+    def test_dispatch_routes_litellm_provider(self):
+        with mock.patch.object(llm, "LLM_PROVIDER", "litellm"), \
+                mock.patch.object(llm, "call_litellm_llm", return_value="ROUTED") as routed:
+            self.assertEqual(llm.call_local_llm("p"), "ROUTED")
+            routed.assert_called_once_with("p")
+
+    def test_dispatch_rejects_unknown_provider(self):
+        with mock.patch.object(llm, "LLM_PROVIDER", "bogus"):
+            with self.assertRaises(RuntimeError) as ctx:
+                llm.call_local_llm("p")
+        self.assertIn("litellm", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds **LiteLLM** as a third `--mode local` highlight ranking backend, alongside the existing OpenAI and Gemini providers. Set `LLM_PROVIDER=litellm` to route highlight detection through [LiteLLM](https://github.com/BerriAI/litellm)'s unified interface, one code path that reaches 100+ providers (OpenAI, Anthropic, Gemini, Bedrock, Azure, Groq, self hosted) or a self hosted **LiteLLM proxy**, by changing `LITELLM_MODEL` and `LITELLM_BASE_URL` instead of the code.

## Why?

Local mode is currently pinned to OpenAI or Gemini. Users who standardise on another provider (Anthropic, Bedrock, Azure, a local vLLM or Ollama endpoint, or a company LiteLLM proxy with shared keys and spend caps) have no first class option. LiteLLM adds all of them through a single dependency.


## Changes

- `shorts_generator/local/llm.py`: `call_litellm_llm()` (lazy `import litellm`, `litellm.completion(..., drop_params=True)`) plus a `litellm` branch in `call_local_llm`.
- `shorts_generator/config.py`: `LITELLM_MODEL`, `LITELLM_API_KEY`, `LITELLM_BASE_URL` (key and base URL optional).
- `requirements-local.txt`: `litellm>=1.85,<1.96`.
- `.env.example`, `README.md`: documented the new provider (feature line, prerequisites, env block, mode comparison table).
- `tests/test_litellm_backend.py`: new unit tests (the repo had no `tests/` yet).

## Tests

**1. Live end to end through the real code path.** `call_local_llm` (with `LLM_PROVIDER=litellm`) calls `call_litellm_llm`, which calls `litellm.completion`, which calls a running LiteLLM proxy, which calls Azure OpenAI, using the actual `detect_content_type` JSON prompt:

```
RAW RESPONSE: '{\n  "content_type": "personal development",\n  "density": "low"\n}'
PARSED JSON: {'content_type': 'personal development', 'density': 'low'}
LIVE_E2E_OK
```

The response parses cleanly through the same `_parse_json_loose` path `highlights.py` uses, so it drops straight into the pipeline.

**2. Unit tests**, `python -m unittest tests.test_litellm_backend -v`:

```
test_call_litellm_llm_shapes_the_request ... ok
test_credentials_forwarded_when_set ... ok
test_dispatch_rejects_unknown_provider ... ok
test_dispatch_routes_litellm_provider ... ok
Ran 4 tests in 0.000s
OK
```

They assert that the request carries `model`, `messages`, and `drop_params=True`; that `LITELLM_API_KEY` and `LITELLM_BASE_URL` are forwarded when set and omitted when blank (so LiteLLM falls back to the upstream provider's own env var); that `LLM_PROVIDER=litellm` dispatches to the new backend; and that an unknown provider still errors. The stub makes them run without the real `litellm` installed.

**3. Version pin verified.** `litellm 1.92.0` (currently installed) satisfies `litellm>=1.85,<1.96`.

## Design notes

- `import litellm` is lazy (inside the function), like the existing `openai` and `google-genai` imports, so the base install and `--mode api` are unaffected; `litellm` is only imported when `LLM_PROVIDER=litellm`.
- `drop_params=True` keeps a single call portable: providers that reject a param (for example a fixed `temperature` on some reasoning models) get it dropped instead of erroring.
- Credentials are forwarded only when set, so a blank `LITELLM_API_KEY` lets LiteLLM read `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` directly.

## Example usage

```bash
# .env
LLM_PROVIDER=litellm
LITELLM_MODEL=anthropic/claude-sonnet-4-5   # or gpt-4o-mini, gemini/..., bedrock/..., or a proxy alias
ANTHROPIC_API_KEY=sk-ant-...                # LiteLLM reads the upstream provider's env key
# Or route through a proxy:
# LITELLM_MODEL=litellm_proxy/my-alias
# LITELLM_BASE_URL=http://localhost:4000
# LITELLM_API_KEY=sk-proxy-virtual-key

python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local
```
